### PR TITLE
feat: support DSH 0.1.0-rc.7 runtime features

### DIFF
--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -1,4 +1,5 @@
 import { withoutIdeContext } from './ide-context.js'
+import type { ImageMediaType } from './dsh-client.js'
 
 export type ConversationRole = 'user' | 'assistant' | 'tool' | 'command' | 'notice'
 
@@ -13,6 +14,17 @@ export interface ConversationMessage {
   resultView?: unknown
   rawInput?: string
   rawResult?: string
+  images?: ConversationImage[]
+}
+
+export interface ConversationImage {
+  attachmentId: string
+  mediaType: ImageMediaType
+  width: number
+  height: number
+  name?: string
+  data?: string
+  error?: string
 }
 
 export interface DshEvent {
@@ -36,6 +48,45 @@ function textContent(value: unknown): string {
     const item = record(part)
     return item?.type === 'text' && typeof item.text === 'string' ? [item.text] : []
   }).join('\n')
+}
+
+function imageMediaType(value: unknown): ImageMediaType | undefined {
+  return value === 'image/png' || value === 'image/jpeg' || value === 'image/webp' || value === 'image/gif'
+    ? value
+    : undefined
+}
+
+/** Finds durable DSH image references, including images nested inside tool results. */
+function imageContent(value: unknown): ConversationImage[] {
+  const found = new Map<string, ConversationImage>()
+  const visit = (candidate: unknown): void => {
+    if (Array.isArray(candidate)) {
+      for (const item of candidate) visit(item)
+      return
+    }
+    const item = record(candidate)
+    if (item === undefined) return
+    if (item.type === 'image') {
+      const attachment = record(item.attachment)
+      const mediaType = imageMediaType(attachment?.mediaType)
+      if (attachment !== undefined
+        && typeof attachment.attachmentId === 'string'
+        && mediaType !== undefined
+        && typeof attachment.width === 'number'
+        && typeof attachment.height === 'number') {
+        found.set(attachment.attachmentId, {
+          attachmentId: attachment.attachmentId,
+          mediaType,
+          width: attachment.width,
+          height: attachment.height,
+          ...(typeof attachment.name === 'string' ? { name: attachment.name } : {}),
+        })
+      }
+    }
+    if (Array.isArray(item.content)) visit(item.content)
+  }
+  visit(value)
+  return [...found.values()]
 }
 
 function resultContent(value: unknown): string {
@@ -75,15 +126,28 @@ export class ConversationProjector {
       if (source?.kind !== 'user') return
       const id = typeof data.id === 'string' ? data.id : `user:${String(event.seq)}`
       const text = withoutIdeContext(textContent(data.content))
-      if (text !== '') this.set(id, { id, role: 'user', text })
+      const images = imageContent(data.content)
+      if (text !== '' || images.length > 0) this.set(id, { id, role: 'user', text, ...(images.length > 0 ? { images } : {}) })
       return
     }
 
     if (event.type === 'assistant/chunk') {
       const chunk = record(data.chunk)
-      if (chunk?.type !== 'text-delta' || typeof chunk.text !== 'string') return
       const id = `assistant:${String(data.turn)}:${String(data.step)}`
       const current = this.byId.get(id)
+      if (chunk?.type === 'block-end') {
+        const images = imageContent(chunk.block)
+        if (images.length === 0) return
+        this.set(id, {
+          id,
+          role: 'assistant',
+          text: current?.text ?? '',
+          images: mergeImages(current?.images, images),
+          streaming: true,
+        })
+        return
+      }
+      if (chunk?.type !== 'text-delta' || typeof chunk.text !== 'string') return
       this.set(id, {
         id,
         role: 'assistant',
@@ -97,7 +161,8 @@ export class ConversationProjector {
       const message = record(data.message)
       const id = `assistant:${String(data.turn)}:${String(data.step)}`
       const text = textContent(message?.content)
-      if (text !== '') this.set(id, { id, role: 'assistant', text })
+      const images = imageContent(message?.content)
+      if (text !== '' || images.length > 0) this.set(id, { id, role: 'assistant', text, ...(images.length > 0 ? { images } : {}) })
       return
     }
 
@@ -129,6 +194,7 @@ export class ConversationProjector {
       const current = this.byId.get(id)
       const failed = data.error !== undefined || firstBlock?.isError === true
       const rawResult = resultContent(firstBlock)
+      const images = imageContent(message?.content)
       this.set(id, {
         id,
         role: 'tool',
@@ -139,6 +205,7 @@ export class ConversationProjector {
         ...(current?.rawInput === undefined ? {} : { rawInput: current.rawInput }),
         resultView: toolView(view, 'result'),
         ...(rawResult === '' ? {} : { rawResult }),
+        ...(images.length > 0 ? { images } : {}),
       })
       return
     }
@@ -187,4 +254,10 @@ export class ConversationProjector {
     if (!this.byId.has(id)) this.orderedIds.push(id)
     this.byId.set(id, message)
   }
+}
+
+function mergeImages(current: readonly ConversationImage[] | undefined, next: readonly ConversationImage[]): ConversationImage[] {
+  const images = new Map((current ?? []).map(image => [image.attachmentId, image]))
+  for (const image of next) images.set(image.attachmentId, image)
+  return [...images.values()]
 }

--- a/src/diff-review.ts
+++ b/src/diff-review.ts
@@ -198,6 +198,12 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
     return this.changedFiles(sessionId)
   }
 
+  /** Replay an older, complete history page without discarding reversible live snapshots. */
+  prependHistory(sessionId: string, cwd: string, entries: readonly HistoryEntry[]): ChangedFileGroup[] {
+    for (const entry of entries) this.accept(sessionId, cwd, entry.event, entry.view, true)
+    return this.changedFiles(sessionId)
+  }
+
   accept(sessionId: string, cwd: string, event: DshEvent, view?: unknown, replay = false): boolean {
     const callId = callIdOf(event)
     if (callId === undefined) return false

--- a/src/dsh-client.ts
+++ b/src/dsh-client.ts
@@ -48,6 +48,15 @@ export interface PromptImage {
   name?: string
 }
 
+export interface ImageAttachment {
+  attachmentId: string
+  mediaType: ImageMediaType
+  bytes: number
+  width: number
+  height: number
+  name?: string
+}
+
 export type PromptMode = 'queue' | 'steer'
 
 export type QueueAction =
@@ -132,6 +141,10 @@ export class DshClient {
 
   models(sessionId: string): Promise<SessionModels> {
     return this.call('session.models', { sessionId })
+  }
+
+  attachment(sessionId: string, attachmentId: string): Promise<{ attachment: ImageAttachment; data: string }> {
+    return this.call('session.attachment', { sessionId, attachmentId })
   }
 
   pluginInventory(): Promise<PluginInventorySnapshot> {

--- a/src/dsh-client.ts
+++ b/src/dsh-client.ts
@@ -136,8 +136,12 @@ export class DshClient {
     return this.call('session.create', { cwd })
   }
 
-  history(sessionId: string): Promise<{ events: HistoryEntry[]; hasMore: boolean }> {
-    return this.call('session.history', { sessionId, maxMessages: 100 })
+  history(sessionId: string, beforeSeq?: number): Promise<{ events: HistoryEntry[]; hasMore: boolean }> {
+    return this.call('session.history', {
+      sessionId,
+      ...(beforeSeq === undefined ? {} : { beforeSeq }),
+      maxMessages: 100,
+    })
   }
 
   models(sessionId: string): Promise<SessionModels> {

--- a/src/dsh-client.ts
+++ b/src/dsh-client.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type { DshEvent } from './conversation.js'
 import type { PluginInventorySnapshot } from './plugin-profile.js'
+import type { SettingsDescription, SettingsMutation, SettingsNamespace } from './runtime-settings.js'
 
 export interface SessionSummary {
   sessionId: string
@@ -149,6 +150,14 @@ export class DshClient {
 
   pluginInventory(): Promise<PluginInventorySnapshot> {
     return this.call('pluginInventory/list', { args: {} })
+  }
+
+  settings(): Promise<SettingsDescription> {
+    return this.call('settings.describe', {})
+  }
+
+  mutateSettings(ns: string, ops: SettingsMutation[], expectedRevision: number): Promise<SettingsNamespace> {
+    return this.call('settings.mutate', { ns, ops, expectedRevision })
   }
 
   prompt(

--- a/src/dsh-client.ts
+++ b/src/dsh-client.ts
@@ -135,7 +135,7 @@ export class DshClient {
   }
 
   pluginInventory(): Promise<PluginInventorySnapshot> {
-    return this.call('pluginInventory/list', {})
+    return this.call('pluginInventory/list', { args: {} })
   }
 
   prompt(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import {
   DshClient,
   type CommandDescriptor,
   type DshFrame,
+  type HistoryEntry,
   type ImageMediaType,
   type ModelSelection,
   type PromptMode,
@@ -34,6 +35,7 @@ import { chatHtml } from './webview.js'
 import { DshPluginManager } from './plugin-manager.js'
 import type { PluginInventorySnapshot } from './plugin-profile.js'
 import type { SettingsDescription, SettingsMutation, SettingsNamespace } from './runtime-settings.js'
+import { earliestHistorySequence, mergeHistoryEntries } from './history.js'
 
 let activeRuntime: DshRuntime | undefined
 
@@ -113,6 +115,8 @@ interface ChatViewState {
   changedFiles: ChangedFileGroup[]
   queue: QueueItemState[]
   jobs: JobItem[]
+  hasMoreHistory: boolean
+  loadingHistory: boolean
 }
 
 function initialState(cwd: string): ChatViewState {
@@ -135,6 +139,8 @@ function initialState(cwd: string): ChatViewState {
     changedFiles: [],
     queue: [],
     jobs: [],
+    hasMoreHistory: false,
+    loadingHistory: false,
   }
 }
 
@@ -156,6 +162,7 @@ class DshChatController implements vscode.Disposable {
   private readonly attachmentResults = new Map<string, Pick<ConversationImage, 'data' | 'error'>>()
   private readonly attachmentLoads = new Map<string, Promise<void>>()
   private readonly jobsBySession = new Map<string, JobItem[]>()
+  private historyEntries: HistoryEntry[] = []
 
   readonly onDidChangeState = this.changes.event
 
@@ -200,6 +207,7 @@ class DshChatController implements vscode.Disposable {
     this.attachmentResults.clear()
     this.attachmentLoads.clear()
     this.jobsBySession.clear()
+    this.historyEntries = []
     this.publish({
       phase: 'loading',
       statusText: 'Starting the official DeepSeek Harness runtime…',
@@ -216,6 +224,8 @@ class DshChatController implements vscode.Disposable {
       changedFiles: [],
       queue: [],
       jobs: [],
+      hasMoreHistory: false,
+      loadingHistory: false,
     })
     try {
       const uri = await this.runtime.start(this.cwd === '' ? undefined : vscode.Uri.file(this.cwd))
@@ -259,6 +269,7 @@ class DshChatController implements vscode.Disposable {
     this._cwd = cwd
     this.summaries = []
     this.projector.reset([])
+    this.historyEntries = []
     this.guardedDirtyCalls.clear()
     this.publish({
       ...initialState(cwd),
@@ -276,6 +287,35 @@ class DshChatController implements vscode.Disposable {
   async selectSession(sessionId: string): Promise<void> {
     if (!this.summaries.some(summary => summary.sessionId === sessionId && summary.cwd === this.cwd)) return
     await this.loadSession(sessionId)
+  }
+
+  async loadOlderHistory(): Promise<void> {
+    if (this._state.sessionId === '' || !this._state.hasMoreHistory || this._state.loadingHistory) return
+    const sessionId = this._state.sessionId
+    const client = this.requireClient()
+    const beforeSeq = earliestHistorySequence(this.historyEntries)
+    if (beforeSeq === undefined) {
+      this.publish({ hasMoreHistory: false })
+      return
+    }
+    this.publish({ loadingHistory: true })
+    try {
+      const page = await client.history(sessionId, beforeSeq)
+      if (this.client !== client || this._state.sessionId !== sessionId) return
+      this.historyEntries = mergeHistoryEntries(this.historyEntries, page.events)
+      this.projector.reset(this.historyEntries)
+      this.publish({
+        messages: this.projectedMessages(),
+        changedFiles: this.diffReviews.prependHistory(sessionId, this.cwd, page.events),
+        hasMoreHistory: page.hasMore,
+        loadingHistory: false,
+      })
+      this.hydrateImages(client, sessionId)
+    } finally {
+      if (this.client === client && this._state.sessionId === sessionId && this._state.loadingHistory) {
+        this.publish({ loadingHistory: false })
+      }
+    }
   }
 
   async send(
@@ -421,13 +461,21 @@ class DshChatController implements vscode.Disposable {
 
   private async loadSession(sessionId: string): Promise<void> {
     const client = this.requireClient()
-    this.publish({ phase: 'loading', statusText: 'Loading project conversation…', sessionId })
-    const [{ events }, models] = await Promise.all([
+    this.historyEntries = []
+    this.publish({
+      phase: 'loading',
+      statusText: 'Loading project conversation…',
+      sessionId,
+      hasMoreHistory: false,
+      loadingHistory: false,
+    })
+    const [{ events, hasMore }, models] = await Promise.all([
       client.history(sessionId),
       client.models(sessionId),
     ])
     if (this.client !== client || this._state.sessionId !== sessionId) return
     this.projector.reset(events)
+    this.historyEntries = events
     this.guardedDirtyCalls.clear()
     this.queueRawText.clear()
     const summary = this.summaries.find(item => item.sessionId === sessionId)
@@ -445,6 +493,8 @@ class DshChatController implements vscode.Disposable {
       changedFiles: this.diffReviews.rebuild(sessionId, this.cwd, events),
       queue: [],
       jobs: this.jobsBySession.get(sessionId) ?? [],
+      hasMoreHistory: hasMore,
+      loadingHistory: false,
       ...this.modelPatch(models),
     })
     this.hydrateImages(client, sessionId)
@@ -505,6 +555,7 @@ class DshChatController implements vscode.Disposable {
       const event = payload.event
       if (typeof event === 'object' && event !== null) {
         const dshEvent = event as DshEvent
+        this.historyEntries = mergeHistoryEntries(this.historyEntries, [{ event: dshEvent, view: payload.view }])
         const conflict = this.dirtyConflict(dshEvent, payload.view)
         if (conflict !== undefined) void this.cancelForDirtyConflict(conflict)
         this.projector.apply(dshEvent, payload.view)
@@ -895,6 +946,7 @@ class DshSurface implements vscode.Disposable {
         case 'select-session':
           if (typeof value.sessionId === 'string') await this.controller.selectSession(value.sessionId)
           return
+        case 'load-history': await this.controller.loadOlderHistory(); return
         case 'send':
           if (typeof value.text === 'string') {
             if (value.text.trim() === '/permission danger-full-access') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import { toolWriteIntents } from './tool-write-guard.js'
 import { chatHtml } from './webview.js'
 import { DshPluginManager } from './plugin-manager.js'
 import type { PluginInventorySnapshot } from './plugin-profile.js'
+import type { SettingsDescription, SettingsMutation, SettingsNamespace } from './runtime-settings.js'
 
 let activeRuntime: DshRuntime | undefined
 
@@ -337,6 +338,14 @@ class DshChatController implements vscode.Disposable {
 
   pluginInventory(): Promise<PluginInventorySnapshot> {
     return this.requireClient().pluginInventory()
+  }
+
+  settings(): Promise<SettingsDescription> {
+    return this.requireClient().settings()
+  }
+
+  mutateSettings(ns: string, ops: SettingsMutation[], expectedRevision: number): Promise<SettingsNamespace> {
+    return this.requireClient().mutateSettings(ns, ops, expectedRevision)
   }
 
   async answerApproval(rpcId: string, approvalId: string, outcome: 'allowed-once' | 'rejected'): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import {
   type SessionSummary,
 } from './dsh-client.js'
 import { replaceTextPreservingIdeContext, withIdeContext, type IdeContextSnapshot } from './ide-context.js'
+import { jobsSnapshotOf, type JobItem } from './jobs.js'
 import { queueSnapshotOf, type QueueItemState } from './queue.js'
 import { DshRuntime, type RuntimeState } from './runtime.js'
 import { toolWriteIntents } from './tool-write-guard.js'
@@ -110,6 +111,7 @@ interface ChatViewState {
   plan: PlanModeState
   changedFiles: ChangedFileGroup[]
   queue: QueueItemState[]
+  jobs: JobItem[]
 }
 
 function initialState(cwd: string): ChatViewState {
@@ -131,6 +133,7 @@ function initialState(cwd: string): ChatViewState {
     plan: planModeStateOf(undefined),
     changedFiles: [],
     queue: [],
+    jobs: [],
   }
 }
 
@@ -151,6 +154,7 @@ class DshChatController implements vscode.Disposable {
   private queueRawText = new Map<string, string>()
   private readonly attachmentResults = new Map<string, Pick<ConversationImage, 'data' | 'error'>>()
   private readonly attachmentLoads = new Map<string, Promise<void>>()
+  private readonly jobsBySession = new Map<string, JobItem[]>()
 
   readonly onDidChangeState = this.changes.event
 
@@ -194,6 +198,7 @@ class DshChatController implements vscode.Disposable {
     this.queueRawText.clear()
     this.attachmentResults.clear()
     this.attachmentLoads.clear()
+    this.jobsBySession.clear()
     this.publish({
       phase: 'loading',
       statusText: 'Starting the official DeepSeek Harness runtime…',
@@ -209,6 +214,7 @@ class DshChatController implements vscode.Disposable {
       plan: planModeStateOf(undefined),
       changedFiles: [],
       queue: [],
+      jobs: [],
     })
     try {
       const uri = await this.runtime.start(this.cwd === '' ? undefined : vscode.Uri.file(this.cwd))
@@ -429,6 +435,7 @@ class DshChatController implements vscode.Disposable {
       plan: planModeStateOf(summary?.projections?.values?.plan),
       changedFiles: this.diffReviews.rebuild(sessionId, this.cwd, events),
       queue: [],
+      jobs: this.jobsBySession.get(sessionId) ?? [],
       ...this.modelPatch(models),
     })
     this.hydrateImages(client, sessionId)
@@ -514,7 +521,20 @@ class DshChatController implements vscode.Disposable {
 
     if (frame.channel === 'mux' && type === 'session/subscribed' && sessionId === this._state.sessionId) {
       this.queueRawText.clear()
-      this.publish({ queue: [] })
+      this.jobsBySession.set(sessionId, [])
+      this.publish({ queue: [], jobs: [] })
+      return
+    }
+
+    if (frame.channel === 'mux' && type === 'session/subscribed') {
+      this.jobsBySession.set(sessionId, [])
+      return
+    }
+
+    if (frame.channel === 'mux' && type === 'session/jobs') {
+      const jobs = jobsSnapshotOf(payload.jobs)
+      this.jobsBySession.set(sessionId, jobs)
+      if (sessionId === this._state.sessionId) this.publish({ jobs })
       return
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import * as path from 'node:path'
 import * as vscode from 'vscode'
-import { ConversationProjector, type ConversationMessage, type DshEvent } from './conversation.js'
+import { ConversationProjector, type ConversationImage, type ConversationMessage, type DshEvent } from './conversation.js'
 import {
   permissionPresetsOf,
   planModeStateOf,
@@ -149,6 +149,8 @@ class DshChatController implements vscode.Disposable {
   private generation = 0
   private readonly guardedDirtyCalls = new Set<string>()
   private queueRawText = new Map<string, string>()
+  private readonly attachmentResults = new Map<string, Pick<ConversationImage, 'data' | 'error'>>()
+  private readonly attachmentLoads = new Map<string, Promise<void>>()
 
   readonly onDidChangeState = this.changes.event
 
@@ -190,6 +192,8 @@ class DshChatController implements vscode.Disposable {
     this.diffReviews.clear()
     this.guardedDirtyCalls.clear()
     this.queueRawText.clear()
+    this.attachmentResults.clear()
+    this.attachmentLoads.clear()
     this.publish({
       phase: 'loading',
       statusText: 'Starting the official DeepSeek Harness runtime…',
@@ -358,7 +362,7 @@ class DshChatController implements vscode.Disposable {
     const message = error instanceof Error ? error.message : String(error)
     this.output.appendLine(`[chat] ${message}`)
     this.projector.notice(`error:${String(Date.now())}`, message, true)
-    this.publish({ messages: this.projector.messages() })
+    this.publish({ messages: this.projectedMessages() })
   }
 
   dispose(): void {
@@ -416,7 +420,7 @@ class DshChatController implements vscode.Disposable {
       phase: 'ready',
       statusText: '',
       sessionId,
-      messages: this.projector.messages(),
+      messages: this.projectedMessages(),
       running: summary?.running ?? false,
       approval: null,
       question: null,
@@ -427,6 +431,7 @@ class DshChatController implements vscode.Disposable {
       queue: [],
       ...this.modelPatch(models),
     })
+    this.hydrateImages(client, sessionId)
     void this.loadCommands(client, sessionId)
   }
 
@@ -499,9 +504,10 @@ class DshChatController implements vscode.Disposable {
           )
         }
         this.publish({
-          messages: this.projector.messages(),
+          messages: this.projectedMessages(),
           ...(changed ? { changedFiles: this.diffReviews.changedFiles(sessionId) } : {}),
         })
+        this.hydrateImages(this.requireClient(), sessionId)
       }
       return
     }
@@ -602,12 +608,52 @@ class DshChatController implements vscode.Disposable {
     if (frame.channel === 'host' && type === 'host/agent-error' && sessionId === this._state.sessionId) {
       const message = typeof payload.message === 'string' ? payload.message : 'DeepSeek Harness reported an agent error.'
       this.projector.notice(`agent-error:${frame.rpcId}`, message, true)
-      this.publish({ messages: this.projector.messages(), running: false })
+      this.publish({ messages: this.projectedMessages(), running: false })
       return
     }
 
     if (frame.channel === 'host' && type === 'host/session-added' && payload.cwd === this.cwd) {
       void this.loadSessions(sessionId).catch(error => { this.report(error) })
+    }
+  }
+
+  private projectedMessages(): ConversationMessage[] {
+    const sessionId = this._state.sessionId
+    return this.projector.messages().map(message => message.images === undefined
+      ? message
+      : {
+          ...message,
+          images: message.images.map(image => ({
+            ...image,
+            ...this.attachmentResults.get(`${sessionId}\u0000${image.attachmentId}`),
+          })),
+        })
+  }
+
+  private hydrateImages(client: DshClient, sessionId: string): void {
+    const images = this.projector.messages().flatMap(message => message.images ?? [])
+    for (const image of images) {
+      const key = `${sessionId}\u0000${image.attachmentId}`
+      if (this.attachmentResults.has(key) || this.attachmentLoads.has(key)) continue
+      const load = client.attachment(sessionId, image.attachmentId)
+        .then((result) => {
+          if (result.attachment.attachmentId !== image.attachmentId || result.attachment.mediaType !== image.mediaType) {
+            throw new Error('DeepSeek Harness returned mismatched image metadata.')
+          }
+          this.attachmentResults.set(key, { data: result.data })
+        })
+        .catch((error: unknown) => {
+          const detail = error instanceof Error ? error.message : String(error)
+          this.output.appendLine(`[attachment] ${image.attachmentId}: ${detail}`)
+          this.attachmentResults.set(key, { error: 'Image unavailable.' })
+        })
+        .finally(() => {
+          this.attachmentLoads.delete(key)
+          if (this.client === client && this._state.sessionId === sessionId) {
+            this.publish({ messages: this.projectedMessages() })
+          }
+        })
+      this.attachmentLoads.set(key, load)
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,7 +35,7 @@ import { chatHtml } from './webview.js'
 import { DshPluginManager } from './plugin-manager.js'
 import type { PluginInventorySnapshot } from './plugin-profile.js'
 import type { SettingsDescription, SettingsMutation, SettingsNamespace } from './runtime-settings.js'
-import { earliestHistorySequence, mergeHistoryEntries } from './history.js'
+import { earliestHistorySequence, mergeHistoryEntries, unseenHistoryEntries } from './history.js'
 
 let activeRuntime: DshRuntime | undefined
 
@@ -302,11 +302,12 @@ class DshChatController implements vscode.Disposable {
     try {
       const page = await client.history(sessionId, beforeSeq)
       if (this.client !== client || this._state.sessionId !== sessionId) return
-      this.historyEntries = mergeHistoryEntries(this.historyEntries, page.events)
+      const unseenEntries = unseenHistoryEntries(this.historyEntries, page.events)
+      this.historyEntries = mergeHistoryEntries(this.historyEntries, unseenEntries)
       this.projector.reset(this.historyEntries)
       this.publish({
         messages: this.projectedMessages(),
-        changedFiles: this.diffReviews.prependHistory(sessionId, this.cwd, page.events),
+        changedFiles: this.diffReviews.prependHistory(sessionId, this.cwd, unseenEntries),
         hasMoreHistory: page.hasMore,
         loadingHistory: false,
       })

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,22 @@
+import type { HistoryEntry } from './dsh-client.js'
+
+/** Merge backwards history pages with live entries using the append-log sequence as identity. */
+export function mergeHistoryEntries(
+  current: readonly HistoryEntry[],
+  incoming: readonly HistoryEntry[],
+): HistoryEntry[] {
+  const bySequence = new Map<number, HistoryEntry>()
+  for (const entry of current) bySequence.set(entry.event.seq, entry)
+  for (const entry of incoming) if (!bySequence.has(entry.event.seq)) bySequence.set(entry.event.seq, entry)
+  return [...bySequence.values()].sort((left, right) => left.event.seq - right.event.seq)
+}
+
+export function earliestHistorySequence(entries: readonly HistoryEntry[]): number | undefined {
+  let earliest: number | undefined
+  for (const entry of entries) {
+    if (!Number.isSafeInteger(entry.event.seq) || entry.event.seq < 0) continue
+    if (earliest === undefined || entry.event.seq < earliest) earliest = entry.event.seq
+  }
+  return earliest
+}
+

--- a/src/history.ts
+++ b/src/history.ts
@@ -11,6 +11,19 @@ export function mergeHistoryEntries(
   return [...bySequence.values()].sort((left, right) => left.event.seq - right.event.seq)
 }
 
+/** Keep only entries whose append-log sequence has not already been loaded. */
+export function unseenHistoryEntries(
+  current: readonly HistoryEntry[],
+  incoming: readonly HistoryEntry[],
+): HistoryEntry[] {
+  const seen = new Set(current.map(entry => entry.event.seq))
+  return incoming.filter((entry) => {
+    if (seen.has(entry.event.seq)) return false
+    seen.add(entry.event.seq)
+    return true
+  })
+}
+
 export function earliestHistorySequence(entries: readonly HistoryEntry[]): number | undefined {
   let earliest: number | undefined
   for (const entry of entries) {
@@ -19,4 +32,3 @@ export function earliestHistorySequence(entries: readonly HistoryEntry[]): numbe
   }
   return earliest
 }
-

--- a/src/jobs.ts
+++ b/src/jobs.ts
@@ -1,0 +1,44 @@
+export type JobStatus = 'running' | 'stopping' | 'completed' | 'killed' | 'failed'
+
+export interface JobItem {
+  id: string
+  kind: string
+  label: string
+  status: JobStatus
+  detail?: string
+  startedAt: number
+  finishedAt?: number
+}
+
+function statusOf(value: unknown): JobStatus | undefined {
+  return value === 'running' || value === 'stopping' || value === 'completed' || value === 'killed' || value === 'failed'
+    ? value
+    : undefined
+}
+
+/** Narrows the authoritative DSH session/jobs snapshot before it reaches the Webview. */
+export function jobsSnapshotOf(value: unknown): JobItem[] {
+  if (!Array.isArray(value)) return []
+  return value.flatMap((candidate): JobItem[] => {
+    if (typeof candidate !== 'object' || candidate === null) return []
+    const item = candidate as Record<string, unknown>
+    const status = statusOf(item.status)
+    if (typeof item.id !== 'string'
+      || typeof item.kind !== 'string'
+      || typeof item.label !== 'string'
+      || status === undefined
+      || typeof item.startedAt !== 'number'
+      || !Number.isFinite(item.startedAt)) return []
+    return [{
+      id: item.id,
+      kind: item.kind,
+      label: item.label,
+      status,
+      startedAt: item.startedAt,
+      ...(typeof item.detail === 'string' ? { detail: item.detail } : {}),
+      ...(typeof item.finishedAt === 'number' && Number.isFinite(item.finishedAt)
+        ? { finishedAt: item.finishedAt }
+        : {}),
+    }]
+  })
+}

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -16,6 +16,16 @@ import {
   type InstalledPluginStatus,
   type PluginInventorySnapshot,
 } from './plugin-profile.js'
+import {
+  hasSettingsOverrides,
+  parseRuntimeSetting,
+  runtimeSettingFields,
+  settingConstantOptions,
+  type RuntimeSettingField,
+  type SettingsDescription,
+  type SettingsMutation,
+  type SettingsNamespace,
+} from './runtime-settings.js'
 
 const CATALOG_CACHE_KEY = 'deepseekHarness.communityRuntimePlugins'
 const MAX_REGISTRY_BYTES = 5 * 1024 * 1024
@@ -33,12 +43,15 @@ interface PluginController {
     running: boolean
   }
   pluginInventory(): Promise<PluginInventorySnapshot>
+  settings(): Promise<SettingsDescription>
+  mutateSettings(ns: string, ops: SettingsMutation[], expectedRevision: number): Promise<SettingsNamespace>
   restart(): Promise<void>
 }
 
 type PluginPick = vscode.QuickPickItem & (
   | { action: 'install' }
   | { action: 'browse' }
+  | { action: 'configure' }
   | { action: 'refresh' }
   | { action: 'plugin'; plugin: InstalledPlugin }
   | { action: 'empty' }
@@ -85,6 +98,10 @@ export class DshPluginManager {
         await this.browseCatalog()
         return
       }
+      if (selected.action === 'configure') {
+        await this.configureSettings()
+        continue
+      }
       if (selected.action === 'refresh') continue
       if (selected.action === 'install') {
         await this.install()
@@ -108,6 +125,11 @@ export class DshPluginManager {
         action: 'browse',
         label: '$(search) Find community runtime plugins…',
         detail: 'Search tools, skills, MCP integrations, memory, and agent hooks; install with one click',
+      },
+      {
+        action: 'configure',
+        label: '$(settings-gear) Configure runtime settings…',
+        detail: 'Edit settings namespaces registered by built-in and community DSH plugins',
       },
       {
         action: 'refresh',
@@ -299,6 +321,174 @@ export class DshPluginManager {
     if (confirmed !== 'Remove') return
     await this.runOfficialPluginCommand(['remove', plugin.name], `Removing ${plugin.name}`)
     await this.restartAfterChange(`Removed ${plugin.name}`)
+  }
+
+  private async configureSettings(): Promise<void> {
+    if (this.controller.state.phase !== 'ready') {
+      await vscode.window.showWarningMessage('Start DeepSeek Harness before configuring runtime settings.')
+      return
+    }
+    let description = await this.controller.settings()
+    if (!description.writable) {
+      await vscode.window.showWarningMessage('The active DSH profile does not expose writable runtime settings.')
+      return
+    }
+    while (true) {
+      const selected = await vscode.window.showQuickPick(description.namespaces.map(namespace => ({
+        label: `$(settings-gear) ${namespace.ns}`,
+        description: hasSettingsOverrides(namespace) ? 'Customized' : 'Default',
+        detail: `${namespace.applies === 'restart' ? 'Requires a runtime restart' : 'Applies immediately'} · ${String(runtimeSettingFields(namespace).length)} settings`,
+        namespace,
+      })), {
+        title: 'DeepSeek Harness Runtime Settings',
+        placeHolder: 'Choose a settings namespace registered by DSH or a runtime plugin',
+        matchOnDescription: true,
+        matchOnDetail: true,
+      })
+      if (selected === undefined) return
+      const changed = await this.configureNamespace(selected.namespace)
+      if (!changed) continue
+      if (selected.namespace.applies === 'restart') {
+        await this.controller.restart()
+        if ((this.controller.state.phase as string) === 'error') {
+          throw new Error(`Settings saved, but DSH could not restart: ${this.controller.state.statusText}`)
+        }
+        await vscode.window.showInformationMessage(`${selected.namespace.ns} updated. DeepSeek Harness restarted.`)
+        return
+      }
+      await vscode.window.showInformationMessage(`${selected.namespace.ns} updated.`)
+      description = await this.controller.settings()
+    }
+  }
+
+  private async configureNamespace(namespace: SettingsNamespace): Promise<boolean> {
+    if (namespace.applies === 'restart' && !await this.requireIdle()) return false
+    const fields = runtimeSettingFields(namespace)
+    type FieldPick = vscode.QuickPickItem & (
+      | { action: 'field'; field: RuntimeSettingField }
+      | { action: 'reset-all' }
+    )
+    const items: FieldPick[] = fields.map(field => ({
+      action: 'field',
+      field,
+      label: field.path.join('.'),
+      description: this.settingSummary(field),
+      detail: `${field.overridden ? 'Customized' : 'Inherited'}${field.node.meta?.description === undefined ? '' : ` · ${field.node.meta.description}`}`,
+    }))
+    if (hasSettingsOverrides(namespace)) {
+      items.unshift({
+        action: 'reset-all',
+        label: '$(discard) Reset all overrides',
+        description: namespace.ns,
+        detail: 'Use the values supplied by DSH and its plugins',
+      })
+    }
+    const selected = await vscode.window.showQuickPick(items, {
+      title: namespace.ns,
+      placeHolder: namespace.applies === 'restart' ? 'Changes restart the DSH runtime' : 'Changes apply immediately',
+      matchOnDescription: true,
+      matchOnDetail: true,
+    })
+    if (selected === undefined) return false
+    if (selected.action === 'reset-all') {
+      const resets: SettingsMutation[] = fields
+        .filter(field => field.overridden)
+        .map(field => ({ op: 'unset', path: field.path }))
+      if (resets.length === 0) return false
+      await this.controller.mutateSettings(namespace.ns, resets, namespace.revision)
+      return true
+    }
+    const mutation = await this.editSetting(namespace, selected.field)
+    if (mutation === undefined) return false
+    await this.controller.mutateSettings(namespace.ns, [mutation], namespace.revision)
+    return true
+  }
+
+  private async editSetting(
+    namespace: SettingsNamespace,
+    field: RuntimeSettingField,
+  ): Promise<SettingsMutation | undefined> {
+    if (field.secretSet !== undefined) return this.editSecret(field)
+    const options = settingConstantOptions(field, namespace.schema)
+    if (options !== undefined) {
+      type ValuePick = vscode.QuickPickItem & ({ value: unknown } | { reset: true })
+      const choices: ValuePick[] = options.map(value => ({
+        label: this.settingValue(value),
+        ...(Object.is(value, field.value) ? { description: 'Current' } : {}),
+        value,
+      }))
+      const choiceItems: ValuePick[] = [
+        ...choices,
+        ...(field.overridden ? [{
+          label: '$(discard) Use inherited value',
+          description: this.settingValue(field.inherited),
+          reset: true as const,
+        }] : []),
+      ]
+      const selected = await vscode.window.showQuickPick(choiceItems, {
+        title: field.path.join('.'), placeHolder: 'Choose a value',
+      })
+      if (selected === undefined) return undefined
+      if ('reset' in selected) return { op: 'unset', path: field.path }
+      return { op: 'set', path: field.path, value: selected.value }
+    }
+    const action = await vscode.window.showQuickPick([
+      { label: '$(edit) Change value', action: 'edit' as const },
+      ...(field.overridden ? [{
+        label: '$(discard) Use inherited value',
+        description: this.settingValue(field.inherited),
+        action: 'reset' as const,
+      }] : []),
+    ], { title: field.path.join('.'), placeHolder: this.settingSummary(field) })
+    if (action === undefined) return undefined
+    if (action.action === 'reset') return { op: 'unset', path: field.path }
+    const input = await vscode.window.showInputBox({
+      title: field.path.join('.'),
+      prompt: field.node.type === 'string' ? 'Enter a string value.' : 'Enter the new value as JSON.',
+      value: field.value === undefined ? '' : field.node.type === 'string' ? String(field.value) : JSON.stringify(field.value),
+      ignoreFocusOut: true,
+      validateInput: source => {
+        try {
+          parseRuntimeSetting(field, source)
+          return undefined
+        } catch (error) {
+          return this.message(error)
+        }
+      },
+    })
+    if (input === undefined) return undefined
+    return { op: 'set', path: field.path, value: parseRuntimeSetting(field, input) }
+  }
+
+  private async editSecret(field: RuntimeSettingField): Promise<SettingsMutation | undefined> {
+    if (field.secretSet) {
+      const action = await vscode.window.showQuickPick([
+        { label: '$(key) Replace secret', action: 'replace' as const },
+        { label: '$(trash) Clear secret', action: 'clear' as const },
+      ], { title: field.path.join('.'), placeHolder: 'The current secret value is never exposed by DSH' })
+      if (action === undefined) return undefined
+      if (action.action === 'clear') return { op: 'unset', path: field.path }
+    }
+    const value = await vscode.window.showInputBox({
+      title: field.path.join('.'),
+      prompt: 'Enter the secret. DSH stores it without returning the value to this extension.',
+      password: true,
+      ignoreFocusOut: true,
+      validateInput: source => source.length === 0 ? 'Secret cannot be empty.' : undefined,
+    })
+    return value === undefined ? undefined : { op: 'set', path: field.path, value }
+  }
+
+  private settingSummary(field: RuntimeSettingField): string {
+    if (field.secretSet !== undefined) return field.secretSet ? 'Configured secret' : 'Secret not set'
+    return this.settingValue(field.value)
+  }
+
+  private settingValue(value: unknown): string {
+    if (value === undefined) return 'Not set'
+    if (typeof value === 'string') return value === '' ? 'Empty string' : value
+    const rendered = JSON.stringify(value)
+    return rendered === undefined ? String(value) : rendered.length > 80 ? `${rendered.slice(0, 77)}…` : rendered
   }
 
   private async requireIdle(): Promise<boolean> {

--- a/src/runtime-settings.ts
+++ b/src/runtime-settings.ts
@@ -1,0 +1,140 @@
+export interface SettingsSchemaNode {
+  type?: string
+  meta?: {
+    description?: string
+    min?: number
+    max?: number
+    step?: number
+    role?: string
+    [key: string]: unknown
+  }
+  dict?: Record<string, number>
+  list?: number[]
+  value?: unknown
+}
+
+export interface SettingsSchema {
+  uid: number
+  refs: Record<string, SettingsSchemaNode>
+}
+
+export interface SettingsSecret {
+  path: string[]
+  set: boolean
+}
+
+export interface SettingsNamespace {
+  ns: string
+  schema: SettingsSchema
+  value: unknown
+  base?: unknown
+  user?: unknown
+  applies: 'live' | 'restart'
+  secrets: SettingsSecret[]
+  revision: number
+}
+
+export interface SettingsDescription {
+  writable: boolean
+  hasDocument: boolean
+  namespaces: SettingsNamespace[]
+}
+
+export type SettingsMutation =
+  | { op: 'set'; path: string[]; value: unknown }
+  | { op: 'unset'; path: string[] }
+
+export interface RuntimeSettingField {
+  path: string[]
+  node: SettingsSchemaNode
+  value: unknown
+  inherited: unknown
+  overridden: boolean
+  secretSet?: boolean
+}
+
+function nodeOf(schema: SettingsSchema, uid: number): SettingsSchemaNode | undefined {
+  return schema.refs[String(uid)]
+}
+
+function valueAt(value: unknown, path: readonly string[]): unknown {
+  let current = value
+  for (const segment of path) {
+    if (current === null || typeof current !== 'object' || Array.isArray(current)) return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function ownsPath(value: unknown, path: readonly string[]): boolean {
+  let current = value
+  for (const segment of path) {
+    if (current === null || typeof current !== 'object' || Array.isArray(current)
+      || !Object.prototype.hasOwnProperty.call(current, segment)) return false
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return true
+}
+
+function samePath(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((part, index) => part === right[index])
+}
+
+export function runtimeSettingFields(namespace: SettingsNamespace): RuntimeSettingField[] {
+  const fields: RuntimeSettingField[] = []
+  const visit = (uid: number, path: string[]): void => {
+    const node = nodeOf(namespace.schema, uid)
+    if (node === undefined) return
+    if (node.type === 'object' && node.dict !== undefined) {
+      for (const [key, childUid] of Object.entries(node.dict)) visit(childUid, [...path, key])
+      return
+    }
+    const secret = namespace.secrets.find(candidate => samePath(candidate.path, path))
+    fields.push({
+      path,
+      node,
+      value: valueAt(namespace.value, path),
+      inherited: valueAt(namespace.base, path),
+      overridden: ownsPath(namespace.user, path),
+      ...(secret === undefined ? {} : { secretSet: secret.set }),
+    })
+  }
+  visit(namespace.schema.uid, [])
+  return fields
+}
+
+export function settingConstantOptions(field: RuntimeSettingField, schema: SettingsSchema): unknown[] | undefined {
+  if (field.node.type === 'boolean') return [true, false]
+  if (field.node.type !== 'union' || field.node.list === undefined) return undefined
+  const options: unknown[] = []
+  for (const uid of field.node.list) {
+    const node = nodeOf(schema, uid)
+    if (node?.type !== 'const') return undefined
+    options.push(node.value)
+  }
+  return options
+}
+
+export function parseRuntimeSetting(field: RuntimeSettingField, source: string): unknown {
+  if (field.node.type === 'string') return source
+  if (field.node.type === 'number') {
+    const value = Number(source)
+    if (!Number.isFinite(value)) throw new Error('Enter a valid number.')
+    const min = field.node.meta?.min
+    const max = field.node.meta?.max
+    if (min !== undefined && value < min) throw new Error(`Value must be at least ${String(min)}.`)
+    if (max !== undefined && value > max) throw new Error(`Value must be at most ${String(max)}.`)
+    return value
+  }
+  try {
+    return JSON.parse(source) as unknown
+  } catch {
+    throw new Error('Enter a valid JSON value.')
+  }
+}
+
+export function hasSettingsOverrides(namespace: SettingsNamespace): boolean {
+  return namespace.user !== null && typeof namespace.user === 'object'
+    && !Array.isArray(namespace.user) && Object.keys(namespace.user).length > 0
+}
+

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -32,6 +32,19 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     .session-select { min-width: 0; flex: 1; border: 0; outline: 0; background: transparent; font-weight: 600; text-overflow: ellipsis; }
     .icon-button { width: 28px; height: 28px; min-width: 28px; padding: 0; display: grid; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--vscode-icon-foreground); }
     .icon-button:hover { background: var(--vscode-toolbar-hoverBackground); }
+    .jobs-control { position: relative; flex: 0 0 auto; }
+    .jobs-trigger { width: auto; min-width: 28px; padding: 0 7px; display: flex; gap: 5px; font-size: 11px; }
+    .jobs-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--vscode-descriptionForeground); }
+    .jobs-trigger.live .jobs-dot { background: var(--vscode-charts-blue, #4d6bfe); box-shadow: 0 0 0 2px color-mix(in srgb, var(--vscode-charts-blue, #4d6bfe) 20%, transparent); }
+    .jobs-menu { position: absolute; z-index: 20; top: calc(100% + 5px); right: 0; width: min(340px, calc(100vw - 20px)); max-height: min(420px, 70vh); padding: 6px; overflow: auto; border: 1px solid var(--vscode-widget-border); border-radius: 8px; background: var(--vscode-menu-background, var(--vscode-editor-background)); box-shadow: 0 5px 18px var(--vscode-widget-shadow); }
+    .jobs-title { padding: 5px 7px 7px; font-size: 11px; font-weight: 600; }
+    .job-row { min-width: 0; display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 2px 7px; padding: 7px; border-radius: 5px; }
+    .job-row + .job-row { border-top: 1px solid color-mix(in srgb, var(--vscode-widget-border) 50%, transparent); }
+    .job-kind { grid-row: 1 / 3; align-self: start; padding: 1px 5px; border-radius: 999px; color: var(--vscode-badge-foreground); background: var(--vscode-badge-background); font-size: 9px; text-transform: uppercase; }
+    .job-label { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 11px; font-weight: 600; }
+    .job-status { color: var(--vscode-descriptionForeground); font-size: 10px; }
+    .job-detail { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; color: var(--vscode-descriptionForeground); font-size: 10px; }
+    .job-duration { grid-column: 3; grid-row: 1 / 3; align-self: center; color: var(--vscode-descriptionForeground); font: 10px var(--vscode-editor-font-family); }
     .icon-button:focus-visible, select:focus-visible, textarea:focus-visible, input:focus-visible, button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
     svg { width: 17px; height: 17px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
     .scroll { min-width: 0; min-height: 0; overflow-x: hidden; overflow-y: auto; scrollbar-color: var(--vscode-scrollbarSlider-background) transparent; }
@@ -185,6 +198,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
   <div id="app">
     <header class="toolbar">
       <select id="sessions" class="session-select" aria-label="Project conversations"></select>
+      <div id="jobsControl" class="jobs-control hidden">
+        <button id="jobsTrigger" class="icon-button jobs-trigger" title="Background jobs" aria-label="Background jobs" aria-haspopup="menu" aria-expanded="false"><span class="jobs-dot"></span><span id="jobsCount">0</span></button>
+        <div id="jobsMenu" class="jobs-menu hidden" role="menu" aria-label="Background jobs"></div>
+      </div>
       <button id="newSession" class="icon-button" title="New conversation" aria-label="New conversation"><svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
     </header>
     <main id="scroll" class="scroll"><div id="conversation" class="conversation"></div></main>
@@ -216,7 +233,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     const vscode = acquireVsCodeApi();
     const elements = {
       conversation: document.getElementById('conversation'), scroll: document.getElementById('scroll'),
-      sessions: document.getElementById('sessions'), newSession: document.getElementById('newSession'),
+      sessions: document.getElementById('sessions'), newSession: document.getElementById('newSession'), jobsControl: document.getElementById('jobsControl'), jobsTrigger: document.getElementById('jobsTrigger'), jobsCount: document.getElementById('jobsCount'), jobsMenu: document.getElementById('jobsMenu'),
       prompt: document.getElementById('prompt'), project: document.getElementById('project'), workspace: document.getElementById('workspace'),
       models: document.getElementById('models'), efforts: document.getElementById('efforts'),
       policyTrigger: document.getElementById('policyTrigger'), policyMenu: document.getElementById('policyMenu'),
@@ -235,6 +252,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let queueEditing = null;
     let queueRenderSignature = '';
     let policyMenuOpen = false;
+    let jobsOpen = false;
+    let jobsTimer;
 
     function node(tag, className, text) {
       const value = document.createElement(tag);
@@ -802,6 +821,34 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         elements.queueDock.append(row);
       }
     }
+    function liveJob(job) { return job.status === 'running' || job.status === 'stopping'; }
+    function jobDuration(job) {
+      const end = liveJob(job) ? Date.now() : (Number(job.finishedAt) || Number(job.startedAt));
+      const seconds = Math.max(0, Math.floor((end - Number(job.startedAt)) / 1000));
+      if (seconds < 60) return seconds + 's';
+      const minutes = Math.floor(seconds / 60); if (minutes < 60) return minutes + 'm ' + (seconds % 60) + 's';
+      return Math.floor(minutes / 60) + 'h ' + (minutes % 60) + 'm';
+    }
+    function renderJobs() {
+      const jobs = array(state && state.jobs);
+      const live = jobs.filter(liveJob).length;
+      elements.jobsControl.classList.toggle('hidden', jobs.length === 0);
+      elements.jobsTrigger.classList.toggle('live', live > 0);
+      elements.jobsCount.textContent = String(live || jobs.length);
+      elements.jobsTrigger.title = live > 0 ? live + ' background ' + (live === 1 ? 'job' : 'jobs') + ' running' : jobs.length + ' background ' + (jobs.length === 1 ? 'job' : 'jobs');
+      if (!jobs.length) { jobsOpen = false; elements.jobsMenu.classList.add('hidden'); elements.jobsTrigger.setAttribute('aria-expanded', 'false'); }
+      elements.jobsMenu.replaceChildren();
+      if (jobs.length) {
+        elements.jobsMenu.append(node('div', 'jobs-title', live > 0 ? 'Background jobs · ' + live + ' running' : 'Background jobs'));
+        const ordered = [...jobs].sort((a, b) => liveJob(a) !== liveJob(b) ? (liveJob(a) ? -1 : 1) : (liveJob(a) ? Number(a.startedAt) - Number(b.startedAt) : Number(b.finishedAt || b.startedAt) - Number(a.finishedAt || a.startedAt)));
+        for (const job of ordered) {
+          const row = node('div', 'job-row'); const status = string(job.detail) || string(job.status);
+          row.title = status; row.append(node('span', 'job-kind', string(job.kind, 'job')), node('span', 'job-label', string(job.label, 'Background job')), node('span', 'job-detail', status), node('span', 'job-duration', jobDuration(job))); elements.jobsMenu.append(row);
+        }
+      }
+      if (jobsTimer) { clearInterval(jobsTimer); jobsTimer = undefined; }
+      if (jobsOpen && live > 0) jobsTimer = setInterval(renderJobs, 1000);
+    }
     function render(current) {
       const nearBottom = elements.scroll.scrollHeight - elements.scroll.scrollTop - elements.scroll.clientHeight < 80;
       state = current; elements.workspace.textContent = current.workspaceName || 'Workspace'; elements.project.title = current.cwd ? 'DeepSeek project: ' + current.cwd : 'Choose DeepSeek project';
@@ -813,6 +860,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (!elements.models.childElementCount) elements.models.append(new Option('Default model', ''));
       renderEfforts((current.models || []).find(model => model.selected) || (current.models || [])[0]);
       renderPolicyState(current);
+      renderJobs();
       elements.conversation.replaceChildren();
       if (current.phase !== 'ready') elements.conversation.append(renderStatus(current));
       else {
@@ -859,6 +907,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     elements.policyTrigger.addEventListener('click', event => {
       event.stopPropagation(); policyMenuOpen = !policyMenuOpen; elements.commandMenu.classList.add('hidden'); elements.mentionMenu.classList.add('hidden'); if (state) renderPolicyState(state);
     });
+    elements.jobsTrigger.addEventListener('click', event => {
+      event.stopPropagation(); jobsOpen = !jobsOpen; elements.jobsMenu.classList.toggle('hidden', !jobsOpen); elements.jobsTrigger.setAttribute('aria-expanded', String(jobsOpen)); renderJobs();
+    });
     elements.project.addEventListener('click', () => vscode.postMessage({ type: 'choose-workspace' }));
     elements.newSession.addEventListener('click', () => vscode.postMessage({ type: 'new-session' })); elements.sessions.addEventListener('change', () => vscode.postMessage({ type: 'select-session', sessionId: elements.sessions.value }));
     elements.models.addEventListener('change', () => {
@@ -868,8 +919,12 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     });
     elements.efforts.addEventListener('change', () => { if (!elements.models.value) return; const selected = JSON.parse(elements.models.value); const model = (state.models || []).find(item => item.provider === selected.provider && item.model === selected.model); if (model) vscode.postMessage({ type: 'select-model', selection: selectionFor(model, elements.efforts.value) }); });
     document.addEventListener('click', event => {
-      if (!policyMenuOpen || elements.policyMenu.contains(event.target) || elements.policyTrigger.contains(event.target)) return;
-      policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false');
+      if (policyMenuOpen && !elements.policyMenu.contains(event.target) && !elements.policyTrigger.contains(event.target)) {
+        policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false');
+      }
+      if (jobsOpen && !elements.jobsMenu.contains(event.target) && !elements.jobsTrigger.contains(event.target)) {
+        jobsOpen = false; elements.jobsMenu.classList.add('hidden'); elements.jobsTrigger.setAttribute('aria-expanded', 'false'); renderJobs();
+      }
     });
     window.addEventListener('message', event => {
       if (!event.data) return;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -19,7 +19,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${token}';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${token}';">
   <style>
     :root { color-scheme: light dark; }
     * { box-sizing: border-box; }
@@ -51,6 +51,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     .message.user { display: flex; flex-direction: column; align-items: flex-end; padding-top: 6px; }
     .user .message-head { display: none; }
     .user .message-body { width: fit-content; max-width: 82%; margin-left: auto; padding: 8px 12px; white-space: pre-wrap; border-radius: 16px; background: color-mix(in srgb, var(--vscode-foreground) 8%, var(--vscode-editor-background)); }
+    .message-images { width: 100%; display: grid; gap: 7px; margin-top: 8px; }
+    .message-image { display: block; max-width: 100%; max-height: 380px; border: 1px solid var(--vscode-widget-border); border-radius: 8px; object-fit: contain; background: var(--vscode-editor-background); }
+    .message-image-status { padding: 8px 10px; border: 1px dashed var(--vscode-widget-border); border-radius: 7px; color: var(--vscode-descriptionForeground); font-size: 11px; }
+    .message-image-status.failed { color: var(--vscode-errorForeground); }
     .pending-steering { opacity: .82; }
     .pending-steering .message-body::after { content: 'Steering…'; display: block; margin-top: 3px; color: var(--vscode-descriptionForeground); font-size: 10px; }
     .markdown > :first-child { margin-top: 0; }
@@ -352,6 +356,22 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function toolTitle(message, callView, resultView) {
       return string(resultView && resultView.title) || string(callView && callView.title) || message.text || 'Tool';
     }
+    function appendImages(parent, images) {
+      if (!Array.isArray(images) || !images.length) return;
+      const gallery = node('div', 'message-images');
+      for (const value of images) {
+        const image = record(value); if (!image) continue;
+        if (typeof image.data === 'string' && typeof image.mediaType === 'string') {
+          const element = document.createElement('img');
+          element.className = 'message-image'; element.alt = string(image.name, 'DeepSeek image');
+          element.width = Number(image.width) || 0; element.height = Number(image.height) || 0;
+          element.src = 'data:' + image.mediaType + ';base64,' + image.data; gallery.append(element);
+        } else {
+          gallery.append(node('div', 'message-image-status' + (image.error ? ' failed' : ''), image.error || 'Loading image…'));
+        }
+      }
+      if (gallery.childNodes.length) parent.append(gallery);
+    }
     function appendPre(parent, text, className) { if (text) parent.append(node('pre', className || '', text)); }
     function renderToolBody(message, callView, resultView) {
       const body = node('div', 'tool-body');
@@ -415,6 +435,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
           if (filePath) row.append(fileButton(filePath, line, filePath + (line ? ':' + String(line) : ''))); body.append(row);
         }
       }
+      appendImages(body, message.images);
       return body;
     }
     function renderTool(message) {
@@ -478,6 +499,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       const body = message.role === 'assistant' ? renderMarkdown(message.text) : node('div', '', message.text);
       body.classList.add('message-body');
       if (message.streaming) body.classList.add('streaming');
+      appendImages(body, message.images);
       item.append(head, body); return item;
     }
     function renderStatus(current) {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -49,6 +49,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     svg { width: 17px; height: 17px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
     .scroll { min-width: 0; min-height: 0; overflow-x: hidden; overflow-y: auto; scrollbar-color: var(--vscode-scrollbarSlider-background) transparent; }
     .conversation { width: 100%; min-width: 0; max-width: 760px; margin: 0 auto; padding: 12px 14px 30px; overflow: hidden; }
+    .history-loader { display: flex; justify-content: center; padding: 1px 0 9px; }
+    .history-button { padding: 3px 9px; border: 0; border-radius: 5px; color: var(--vscode-textLink-foreground); background: transparent; font-size: 11px; }
+    .history-button:hover { background: var(--vscode-toolbar-hoverBackground); }
     .empty { min-height: 55vh; display: grid; place-content: center; justify-items: center; text-align: center; padding: 28px 10px; }
     .deepseek-mark { background-color: #4d6bfe; -webkit-mask: url("${mark}") center / contain no-repeat; mask: url("${mark}") center / contain no-repeat; }
     .empty-logo { width: 38px; height: 38px; margin-bottom: 13px; }
@@ -254,6 +257,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let policyMenuOpen = false;
     let jobsOpen = false;
     let jobsTimer;
+    let historyAnchor;
 
     function node(tag, className, text) {
       const value = document.createElement(tag);
@@ -851,6 +855,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     }
     function render(current) {
       const nearBottom = elements.scroll.scrollHeight - elements.scroll.scrollTop - elements.scroll.clientHeight < 80;
+      const preservingHistory = historyAnchor && historyAnchor.sessionId === current.sessionId;
       state = current; elements.workspace.textContent = current.workspaceName || 'Workspace'; elements.project.title = current.cwd ? 'DeepSeek project: ' + current.cwd : 'Choose DeepSeek project';
       elements.sessions.replaceChildren();
       for (const session of current.sessions || []) { const option = new Option(session.title, session.id, false, session.id === current.sessionId); elements.sessions.append(option); }
@@ -864,6 +869,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       elements.conversation.replaceChildren();
       if (current.phase !== 'ready') elements.conversation.append(renderStatus(current));
       else {
+        if (current.hasMoreHistory || current.loadingHistory) {
+          const loader = node('div', 'history-loader'); const button = node('button', 'history-button', current.loadingHistory ? 'Loading earlier messages…' : 'Load earlier messages'); button.type = 'button'; button.disabled = current.loadingHistory === true;
+          button.addEventListener('click', () => { historyAnchor = { sessionId: current.sessionId, height: elements.scroll.scrollHeight, top: elements.scroll.scrollTop }; button.disabled = true; button.textContent = 'Loading earlier messages…'; vscode.postMessage({ type: 'load-history' }); }); loader.append(button); elements.conversation.append(loader);
+        }
         if (!current.messages || current.messages.length === 0) elements.conversation.append(renderEmpty(current));
         else for (const message of current.messages) elements.conversation.append(renderMessage(message));
         for (const item of current.queue || []) if (item.placement === 'steering') elements.conversation.append(renderPendingSteering(item));
@@ -876,7 +885,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       elements.models.disabled = !enabled || !(current.models || []).length; elements.efforts.disabled = !enabled || !elements.efforts.options.length || elements.efforts.value === '';
       elements.cancel.classList.toggle('hidden', current.running !== true); elements.send.title = current.running ? 'Queue message (Enter) · Steer now (Cmd/Ctrl+Enter)' : 'Send (Enter)'; updateSend(); renderQueue();
       renderCommandMenu();
-      if (nearBottom || current.approval || current.question) requestAnimationFrame(() => { elements.scroll.scrollTop = elements.scroll.scrollHeight; });
+      if (preservingHistory && current.loadingHistory !== true) {
+        const anchor = historyAnchor; historyAnchor = undefined;
+        requestAnimationFrame(() => { elements.scroll.scrollTop = anchor.top + elements.scroll.scrollHeight - anchor.height; });
+      } else if (!preservingHistory && (nearBottom || current.approval || current.question)) requestAnimationFrame(() => { elements.scroll.scrollTop = elements.scroll.scrollHeight; });
     }
     function updateSend() { elements.send.disabled = !state || state.phase !== 'ready' || (elements.prompt.value.trim() === '' && draftImages.length === 0); }
     function resizePrompt() { elements.prompt.style.height = 'auto'; elements.prompt.style.height = Math.min(elements.prompt.scrollHeight, 220) + 'px'; updateSend(); }

--- a/tests/conversation.spec.ts
+++ b/tests/conversation.spec.ts
@@ -92,6 +92,74 @@ describe('ConversationProjector', () => {
     })])
   })
 
+  it('keeps durable assistant and nested tool-result images for client-side loading', () => {
+    const projector = new ConversationProjector()
+    projector.apply(event('assistant/message', 1, {
+      turn: 1,
+      step: 1,
+      message: {
+        content: [{
+          type: 'image',
+          attachment: {
+            attachmentId: 'assistant-image',
+            mediaType: 'image/png',
+            bytes: 100,
+            width: 20,
+            height: 10,
+            name: 'chart.png',
+          },
+        }],
+      },
+    }))
+    projector.apply(event('tool/call', 2, { callId: 'image-call', name: 'mcp_image' }))
+    projector.apply(event('tool/result', 3, {
+      message: {
+        source: { kind: 'tool', callId: 'image-call' },
+        content: [{
+          type: 'tool-result',
+          toolCallId: 'image-call',
+          content: [{
+            type: 'tool-result',
+            toolCallId: 'nested',
+            content: [{
+              type: 'image',
+              attachment: {
+                attachmentId: 'tool-image',
+                mediaType: 'image/webp',
+                bytes: 200,
+                width: 40,
+                height: 30,
+              },
+            }],
+          }],
+        }],
+      },
+    }))
+
+    expect(projector.messages()).toEqual([
+      expect.objectContaining({
+        id: 'assistant:1:1',
+        text: '',
+        images: [{
+          attachmentId: 'assistant-image',
+          mediaType: 'image/png',
+          width: 20,
+          height: 10,
+          name: 'chart.png',
+        }],
+      }),
+      expect.objectContaining({
+        id: 'tool:image-call',
+        images: [{
+          attachmentId: 'tool-image',
+          mediaType: 'image/webp',
+          width: 40,
+          height: 30,
+        }],
+      }),
+    ])
+  })
+
   it('folds official command lifecycle events into one card', () => {
     const projector = new ConversationProjector()
     projector.apply(event('command/run', 1, { commandId: 'command-1', name: 'plan', args: ' off' }))

--- a/tests/diff-review.spec.ts
+++ b/tests/diff-review.spec.ts
@@ -130,6 +130,40 @@ describe('DiffReviewManager', () => {
     expect(fs.readFileSync(filePath, 'utf8')).toBe('const value = 1\n')
   })
 
+  it('prepends older review history without losing reversible live snapshots', () => {
+    const cwd = temporaryWorkspace()
+    const filePath = path.join(cwd, 'current.ts')
+    fs.writeFileSync(filePath, 'before\n')
+    const manager = new DiffReviewManager()
+    const liveCall = event('tool/call', 20, { turn: 2, callId: 'live', name: 'edit' })
+    const liveResult = event('tool/result', 21, {
+      turn: 2,
+      message: { source: { kind: 'tool', callId: 'live' }, content: [{ type: 'tool-result', toolCallId: 'live' }] },
+    })
+    const liveCallView = { for: 'call', view: { card: 'diff', diffs: [{ path: 'current.ts', oldText: 'before', newText: 'after' }] } }
+    const liveResultView = { for: 'result', view: { card: 'diff', diffs: [{ path: 'current.ts', oldText: 'before', newText: 'after' }] } }
+    manager.accept('session-pages', cwd, liveCall, liveCallView)
+    fs.writeFileSync(filePath, 'after\n')
+    manager.accept('session-pages', cwd, liveResult, liveResultView)
+
+    const changed = manager.prependHistory('session-pages', cwd, [
+      {
+        event: event('tool/call', 1, { turn: 1, callId: 'older', name: 'write' }),
+        view: { for: 'call', view: { card: 'diff', diffs: [{ path: 'old.ts', oldText: null, newText: 'old' }] } },
+      },
+      {
+        event: event('tool/result', 2, {
+          turn: 1,
+          message: { source: { kind: 'tool', callId: 'older' }, content: [{ type: 'tool-result', toolCallId: 'older' }] },
+        }),
+        view: { for: 'result', view: { card: 'diff', diffs: [{ path: 'old.ts', oldText: null, newText: 'old' }] } },
+      },
+    ])
+
+    expect(changed.find(group => group.turn === 2)?.files[0]?.canRevert).toBe(true)
+    expect(changed.find(group => group.turn === 1)?.files[0]?.canRevert).toBe(false)
+  })
+
   it('refuses to overwrite a file changed after DeepSeek edited it', () => {
     const cwd = temporaryWorkspace()
     const filePath = path.join(cwd, 'app.ts')

--- a/tests/dsh-client.spec.ts
+++ b/tests/dsh-client.spec.ts
@@ -113,4 +113,37 @@ describe('DshClient queue protocol', () => {
       payload: { sessionId: 'session-1', attachmentId: 'sha256:image' },
     }])
   })
+
+  it('describes and mutates official runtime settings with revision protection', async () => {
+    const requests: Array<{ method: string; payload: unknown }> = []
+    vi.stubGlobal('fetch', vi.fn(async (_url: URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { rpcId: string; method: string; payload: unknown }
+      requests.push({ method: request.method, payload: request.payload })
+      return new Response(JSON.stringify({
+        type: 'server-response',
+        rpcId: request.rpcId,
+        result: { ok: true, value: request.method === 'settings.describe'
+          ? { writable: true, hasDocument: true, namespaces: [] }
+          : { ns: 'agent-loop', revision: 4 } },
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }))
+    const client = new DshClient(new URL('http://127.0.0.1:31415'))
+
+    await client.settings()
+    await client.mutateSettings('agent-loop', [{
+      op: 'set', path: ['maxParallelToolCalls'], value: 4,
+    }], 3)
+
+    expect(requests).toEqual([
+      { method: 'settings.describe', payload: {} },
+      {
+        method: 'settings.mutate',
+        payload: {
+          ns: 'agent-loop',
+          ops: [{ op: 'set', path: ['maxParallelToolCalls'], value: 4 }],
+          expectedRevision: 3,
+        },
+      },
+    ])
+  })
 })

--- a/tests/dsh-client.spec.ts
+++ b/tests/dsh-client.spec.ts
@@ -146,4 +146,25 @@ describe('DshClient queue protocol', () => {
       },
     ])
   })
+
+  it('requests older history using the official beforeSeq cursor', async () => {
+    const requests: Array<{ method: string; payload: unknown }> = []
+    vi.stubGlobal('fetch', vi.fn(async (_url: URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { rpcId: string; method: string; payload: unknown }
+      requests.push({ method: request.method, payload: request.payload })
+      return new Response(JSON.stringify({
+        type: 'server-response', rpcId: request.rpcId,
+        result: { ok: true, value: { events: [], hasMore: false } },
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }))
+    const client = new DshClient(new URL('http://127.0.0.1:31415'))
+
+    await client.history('session-1')
+    await client.history('session-1', 42)
+
+    expect(requests).toEqual([
+      { method: 'session.history', payload: { sessionId: 'session-1', maxMessages: 100 } },
+      { method: 'session.history', payload: { sessionId: 'session-1', beforeSeq: 42, maxMessages: 100 } },
+    ])
+  })
 })

--- a/tests/dsh-client.spec.ts
+++ b/tests/dsh-client.spec.ts
@@ -81,4 +81,36 @@ describe('DshClient queue protocol', () => {
     })
     expect(requests).toEqual([{ method: 'pluginInventory/list', payload: { args: {} } }])
   })
+
+  it('reads a durable image through its authorizing session', async () => {
+    const requests: Array<{ method: string; payload: unknown }> = []
+    vi.stubGlobal('fetch', vi.fn(async (_url: URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { rpcId: string; method: string; payload: unknown }
+      requests.push({ method: request.method, payload: request.payload })
+      return new Response(JSON.stringify({
+        type: 'server-response',
+        rpcId: request.rpcId,
+        result: {
+          ok: true,
+          value: {
+            attachment: {
+              attachmentId: 'sha256:image',
+              mediaType: 'image/png',
+              bytes: 3,
+              width: 1,
+              height: 1,
+            },
+            data: 'YWJj',
+          },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }))
+    const client = new DshClient(new URL('http://127.0.0.1:31415'))
+
+    await expect(client.attachment('session-1', 'sha256:image')).resolves.toMatchObject({ data: 'YWJj' })
+    expect(requests).toEqual([{
+      method: 'session.attachment',
+      payload: { sessionId: 'session-1', attachmentId: 'sha256:image' },
+    }])
+  })
 })

--- a/tests/dsh-client.spec.ts
+++ b/tests/dsh-client.spec.ts
@@ -79,6 +79,6 @@ describe('DshClient queue protocol', () => {
         fiberPhase: 'active',
       }],
     })
-    expect(requests).toEqual([{ method: 'pluginInventory/list', payload: {} }])
+    expect(requests).toEqual([{ method: 'pluginInventory/list', payload: { args: {} } }])
   })
 })

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { earliestHistorySequence, mergeHistoryEntries } from '../src/history.js'
+import { earliestHistorySequence, mergeHistoryEntries, unseenHistoryEntries } from '../src/history.js'
 import type { HistoryEntry } from '../src/dsh-client.js'
 
 function entry(seq: number, label: string): HistoryEntry {
@@ -8,11 +8,12 @@ function entry(seq: number, label: string): HistoryEntry {
 
 describe('history pagination', () => {
   it('prepends older events in sequence order without duplicating an overlapping event', () => {
-    const merged = mergeHistoryEntries(
-      [entry(10, 'current'), entry(11, 'live')],
-      [entry(2, 'older'), entry(10, 'duplicate')],
-    )
+    const current = [entry(10, 'current'), entry(11, 'live')]
+    const incoming = [entry(2, 'older'), entry(10, 'overlap'), entry(2, 'duplicate in page')]
+    const unseen = unseenHistoryEntries(current, incoming)
+    const merged = mergeHistoryEntries(current, unseen)
 
+    expect(unseen.map(item => item.event.seq)).toEqual([2])
     expect(merged.map(item => item.event.seq)).toEqual([2, 10, 11])
     expect((merged[1]?.view as { label: string }).label).toBe('current')
     expect(earliestHistorySequence(merged)).toBe(2)

--- a/tests/history.spec.ts
+++ b/tests/history.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { earliestHistorySequence, mergeHistoryEntries } from '../src/history.js'
+import type { HistoryEntry } from '../src/dsh-client.js'
+
+function entry(seq: number, label: string): HistoryEntry {
+  return { event: { type: 'user/message', seq, time: seq, data: { label } }, view: { label } }
+}
+
+describe('history pagination', () => {
+  it('prepends older events in sequence order without duplicating an overlapping event', () => {
+    const merged = mergeHistoryEntries(
+      [entry(10, 'current'), entry(11, 'live')],
+      [entry(2, 'older'), entry(10, 'duplicate')],
+    )
+
+    expect(merged.map(item => item.event.seq)).toEqual([2, 10, 11])
+    expect((merged[1]?.view as { label: string }).label).toBe('current')
+    expect(earliestHistorySequence(merged)).toBe(2)
+  })
+})

--- a/tests/jobs.spec.ts
+++ b/tests/jobs.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { jobsSnapshotOf } from '../src/jobs.js'
+
+describe('jobsSnapshotOf', () => {
+  it('keeps the official background job view and rejects malformed rows', () => {
+    expect(jobsSnapshotOf([
+      {
+        id: 'subagent-1',
+        kind: 'subagent',
+        label: 'Review the API',
+        status: 'running',
+        startedAt: 100,
+      },
+      {
+        id: 'bash-2',
+        kind: 'bash',
+        label: 'npm test',
+        status: 'failed',
+        detail: 'exit code: 1',
+        startedAt: 200,
+        finishedAt: 250,
+      },
+      { id: 'bad', kind: 'bash', label: 'bad', status: 'unknown', startedAt: 1 },
+    ])).toEqual([
+      {
+        id: 'subagent-1',
+        kind: 'subagent',
+        label: 'Review the API',
+        status: 'running',
+        startedAt: 100,
+      },
+      {
+        id: 'bash-2',
+        kind: 'bash',
+        label: 'npm test',
+        status: 'failed',
+        detail: 'exit code: 1',
+        startedAt: 200,
+        finishedAt: 250,
+      },
+    ])
+  })
+})

--- a/tests/runtime-settings.spec.ts
+++ b/tests/runtime-settings.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseRuntimeSetting,
+  runtimeSettingFields,
+  settingConstantOptions,
+  type SettingsNamespace,
+} from '../src/runtime-settings.js'
+
+const namespace: SettingsNamespace = {
+  ns: 'example-plugin',
+  schema: {
+    uid: 8,
+    refs: {
+      '1': { type: 'const', value: 'off' },
+      '2': { type: 'const', value: 'on' },
+      '3': { type: 'union', list: [1, 2] },
+      '4': { type: 'number', meta: { min: 1, max: 10 } },
+      '5': { type: 'string', meta: { role: 'secret' } },
+      '6': { type: 'object', dict: { limit: 4 } },
+      '8': { type: 'object', dict: { mode: 3, nested: 6, token: 5 } },
+    },
+  },
+  value: { mode: 'on', nested: { limit: 4 } },
+  base: { mode: 'off', nested: { limit: 2 } },
+  user: { mode: 'on', nested: { limit: 4 } },
+  applies: 'restart',
+  secrets: [{ path: ['token'], set: true }],
+  revision: 7,
+}
+
+describe('runtime settings schemas', () => {
+  it('flattens Schemastery object fields while preserving overrides and redacted secrets', () => {
+    const fields = runtimeSettingFields(namespace)
+
+    expect(fields.map(field => field.path.join('.'))).toEqual(['mode', 'nested.limit', 'token'])
+    expect(fields[0]).toMatchObject({ value: 'on', inherited: 'off', overridden: true })
+    expect(fields[2]).toMatchObject({ value: undefined, overridden: false, secretSet: true })
+    expect(settingConstantOptions(fields[0]!, namespace.schema)).toEqual(['off', 'on'])
+  })
+
+  it('parses and validates typed setting input', () => {
+    const numberField = runtimeSettingFields(namespace)[1]!
+    expect(parseRuntimeSetting(numberField, '8')).toBe(8)
+    expect(() => parseRuntimeSetting(numberField, '0')).toThrow('at least 1')
+    expect(() => parseRuntimeSetting(numberField, 'not-a-number')).toThrow('valid number')
+  })
+})


### PR DESCRIPTION
## Summary

Adapt the VS Code sidebar to the runtime capabilities and protocol contracts available in DSH 0.1.0-rc.7.

- Use the official payload for `pluginInventory/list`
- Render persistent image attachments, including images returned by nested tool results
- Show live background jobs and their completion status in the session header
- Add native configuration for DSH runtime setting namespaces
- Load older session history with `beforeSeq` pagination while preserving scroll position
- Preserve reversible Changed Files snapshots when older history is loaded

## Runtime settings

Runtime settings are discovered through `settings.describe` and updated through `settings.mutate`.

The UI supports:

- Plugin-owned and built-in namespaces
- String, number, boolean, enum, JSON, and secret values
- Nested setting paths
- Revision-protected updates
- Inherited-value reset
- Runtime restart when required by the namespace

## Validation

- `npm run check`
- 14 test files passed
- 54 tests passed
- Verified against a real DSH 0.1.0-rc.7 runtime
- Confirmed discovery of 12 runtime setting namespaces
- Confirmed enum rendering for `permission.defaultPreset`
- Confirmed live background-job updates from running to completion
- Confirmed real `settings.mutate` and `session.history` pagination requests

Durable image hydration is covered by protocol and projection tests. The currently available DeepSeek model route does not declare image input, so a successful live `read_image` result could not be produced during manual validation.
