### PR TITLE
fix: launch npm-installed DSH on Windows

### DIFF
--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, join, resolve } from 'node:path'
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 export interface LaunchCommand {
@@ -10,7 +10,84 @@ export interface LaunchCommand {
   env?: Readonly<Record<string, string>>
 }
 
+interface LaunchHost {
+  platform: NodeJS.Platform
+  execPath: string
+  env: Readonly<Record<string, string | undefined>>
+}
+
 const SOURCE_ROOT_PACKAGE = '@deepseek-ai/dsh-root'
+const INSTALLED_PACKAGE = '@deepseek-ai/dsh'
+
+function hostPath(env: Readonly<Record<string, string | undefined>>): string {
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toLowerCase() === 'path') return value ?? ''
+  }
+  return ''
+}
+
+function windowsPathDirectories(env: Readonly<Record<string, string | undefined>>): string[] {
+  return hostPath(env)
+    .split(';')
+    .map(value => value.trim().replace(/^"|"$/g, ''))
+    .filter(value => value !== '')
+}
+
+function installedDshEntry(binDirectory: string): string | undefined {
+  const packageRoot = join(binDirectory, 'node_modules', '@deepseek-ai', 'dsh')
+  const manifestPath = join(packageRoot, 'package.json')
+  if (!existsSync(manifestPath)) return undefined
+
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      name?: unknown
+      bin?: unknown
+    }
+    if (manifest.name !== INSTALLED_PACKAGE) return undefined
+    const bin = typeof manifest.bin === 'string'
+      ? manifest.bin
+      : typeof manifest.bin === 'object' && manifest.bin !== null
+        ? (manifest.bin as Record<string, unknown>).dsh
+        : undefined
+    if (typeof bin !== 'string') return undefined
+    const entry = resolve(packageRoot, bin)
+    const packageRelative = relative(packageRoot, entry)
+    if (packageRelative.startsWith('..') || isAbsolute(packageRelative) || !existsSync(entry)) return undefined
+    return entry
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * npm exposes global binaries as .cmd shims on Windows. Node cannot execute
+ * those shims without a shell, while spawn(..., { shell: true }) leaves args
+ * unescaped (DEP0190). Resolve npm's real JS entry and run it in Electron's
+ * Node mode instead.
+ */
+function resolveWindowsDsh(
+  executable: string,
+  configuredArgs: readonly string[],
+  host: LaunchHost,
+): LaunchCommand | undefined {
+  if (executable !== '' && basename(executable).toLowerCase() !== 'dsh.cmd') return undefined
+
+  const directories = isAbsolute(executable)
+    ? [dirname(executable)]
+    : windowsPathDirectories(host.env)
+  for (const directory of directories) {
+    if (!existsSync(join(directory, 'dsh.cmd'))) continue
+    const entry = installedDshEntry(directory)
+    if (entry === undefined) continue
+    return {
+      command: host.execPath,
+      args: [entry, ...configuredArgs],
+      sourceCheckout: false,
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+    }
+  }
+  return undefined
+}
 
 function resolveTsxImport(sourceRoot: string): string {
   try {
@@ -58,9 +135,24 @@ export function resolveLaunch(
   extensionPath: string,
   executable: string,
   configuredArgs: readonly string[],
+  overrides: Partial<LaunchHost> = {},
 ): LaunchCommand {
-  if (executable.trim() !== '') {
-    return { command: executable, args: [...configuredArgs], sourceCheckout: false }
+  const configuredExecutable = executable.trim()
+  const host: LaunchHost = {
+    platform: overrides.platform ?? process.platform,
+    execPath: overrides.execPath ?? process.execPath,
+    env: overrides.env ?? process.env,
+  }
+
+  if (configuredExecutable !== '') {
+    const windowsLaunch = host.platform === 'win32'
+      ? resolveWindowsDsh(configuredExecutable, configuredArgs, host)
+      : undefined
+    return windowsLaunch ?? {
+      command: configuredExecutable,
+      args: [...configuredArgs],
+      sourceCheckout: false,
+    }
   }
 
   const sourceRoot = findSourceRoot(extensionPath)
@@ -84,8 +176,13 @@ export function resolveLaunch(
     }
   }
 
+  if (host.platform === 'win32') {
+    const windowsLaunch = resolveWindowsDsh('', configuredArgs, host)
+    if (windowsLaunch !== undefined) return windowsLaunch
+  }
+
   return {
-    command: process.platform === 'win32' ? 'dsh.cmd' : 'dsh',
+    command: host.platform === 'win32' ? 'dsh.cmd' : 'dsh',
     args: [...configuredArgs],
     sourceCheckout: false,
   }

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -12,7 +12,6 @@ export interface LaunchCommand {
 
 interface LaunchHost {
   platform: NodeJS.Platform
-  execPath: string
   env: Readonly<Record<string, string | undefined>>
 }
 
@@ -59,6 +58,20 @@ function installedDshEntry(binDirectory: string): string | undefined {
   }
 }
 
+/** Match the runtime selection performed by npm's Windows command shim. */
+function windowsNodeExecutable(
+  binDirectory: string,
+  env: Readonly<Record<string, string | undefined>>,
+): string | undefined {
+  const adjacent = join(binDirectory, 'node.exe')
+  if (existsSync(adjacent)) return adjacent
+  for (const directory of windowsPathDirectories(env)) {
+    const candidate = join(directory, 'node.exe')
+    if (existsSync(candidate)) return candidate
+  }
+  return undefined
+}
+
 /**
  * npm exposes global binaries as .cmd shims on Windows. Node cannot execute
  * those shims without a shell, while spawn(..., { shell: true }) leaves args
@@ -79,11 +92,12 @@ function resolveWindowsDsh(
     if (!existsSync(join(directory, 'dsh.cmd'))) continue
     const entry = installedDshEntry(directory)
     if (entry === undefined) continue
+    const node = windowsNodeExecutable(directory, host.env)
+    if (node === undefined) continue
     return {
-      command: host.execPath,
+      command: node,
       args: [entry, ...configuredArgs],
       sourceCheckout: false,
-      env: { ELECTRON_RUN_AS_NODE: '1' },
     }
   }
   return undefined
@@ -140,7 +154,6 @@ export function resolveLaunch(
   const configuredExecutable = executable.trim()
   const host: LaunchHost = {
     platform: overrides.platform ?? process.platform,
-    execPath: overrides.execPath ?? process.execPath,
     env: overrides.env ?? process.env,
   }
 

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 export interface LaunchCommand {
@@ -13,6 +13,7 @@ export interface LaunchCommand {
 interface LaunchHost {
   platform: NodeJS.Platform
   env: Readonly<Record<string, string | undefined>>
+  cwd: string
 }
 
 const SOURCE_ROOT_PACKAGE = '@deepseek-ai/dsh-root'
@@ -30,6 +31,15 @@ function windowsPathDirectories(env: Readonly<Record<string, string | undefined>
     .split(';')
     .map(value => value.trim().replace(/^"|"$/g, ''))
     .filter(value => value !== '')
+}
+
+function executableBasename(executable: string): string {
+  return executable.split(/[\\/]/).at(-1) ?? executable
+}
+
+function explicitExecutablePath(executable: string, cwd: string): string {
+  if (isAbsolute(executable)) return executable
+  return resolve(cwd, ...executable.split(/[\\/]+/))
 }
 
 function installedDshEntry(binDirectory: string): string | undefined {
@@ -83,11 +93,14 @@ function resolveWindowsDsh(
   configuredArgs: readonly string[],
   host: LaunchHost,
 ): LaunchCommand | undefined {
-  if (executable !== '' && basename(executable).toLowerCase() !== 'dsh.cmd') return undefined
+  if (executable !== '' && executableBasename(executable).toLowerCase() !== 'dsh.cmd') return undefined
 
-  const directories = isAbsolute(executable)
-    ? [dirname(executable)]
-    : windowsPathDirectories(host.env)
+  const explicitPath = executable !== '' && /[\\/]/.test(executable)
+    ? explicitExecutablePath(executable, host.cwd)
+    : undefined
+  const directories = explicitPath === undefined
+    ? windowsPathDirectories(host.env)
+    : [dirname(explicitPath)]
   for (const directory of directories) {
     if (!existsSync(join(directory, 'dsh.cmd'))) continue
     const entry = installedDshEntry(directory)
@@ -155,6 +168,7 @@ export function resolveLaunch(
   const host: LaunchHost = {
     platform: overrides.platform ?? process.platform,
     env: overrides.env ?? process.env,
+    cwd: overrides.cwd ?? process.cwd(),
   }
 
   if (configuredExecutable !== '') {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -69,7 +69,9 @@ export class DshRuntime implements vscode.Disposable {
     const configuredExecutable = config.get<string>('executable', '')
     const args = config.get<string[]>('arguments', ['web', '--host', '127.0.0.1', '--port', '0'])
     const timeoutMs = config.get<number>('startupTimeout', 60_000)
-    const launch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, args)
+    const launch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, args, {
+      cwd: workspace.fsPath,
+    })
     const storedApiKey = await this.context.secrets.get(DEEPSEEK_API_KEY_SECRET)
 
     const pending = deferredStart()

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -53,4 +53,65 @@ describe('DSH launch resolution', () => {
       sourceCheckout: false,
     })
   })
+
+  it('launches an npm-installed DSH entry directly on Windows', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-prefix-'))
+    const packageRoot = join(prefix, 'node_modules', '@deepseek-ai', 'dsh')
+    const entry = join(packageRoot, 'lib', 'bin.js')
+    mkdirSync(join(packageRoot, 'lib'), { recursive: true })
+    writeFileSync(join(prefix, 'dsh.cmd'), '@echo off\r\n')
+    writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh',
+      bin: { dsh: 'lib/bin.js' },
+    }))
+    writeFileSync(entry, '')
+
+    expect(resolveLaunch('/not/a/source/tree', '', ['web', '--port', '0'], {
+      platform: 'win32',
+      execPath: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      env: { Path: prefix },
+    })).toEqual({
+      command: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      args: [entry, 'web', '--port', '0'],
+      sourceCheckout: false,
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+    })
+  })
+
+  it('keeps the dsh.cmd fallback when a Windows install cannot be resolved safely', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-missing-'))
+    expect(resolveLaunch('/not/a/source/tree', '', ['web'], {
+      platform: 'win32',
+      execPath: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      env: { Path: prefix },
+    })).toEqual({
+      command: 'dsh.cmd',
+      args: ['web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('resolves an explicitly configured npm dsh.cmd on Windows', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-explicit-'))
+    const packageRoot = join(prefix, 'node_modules', '@deepseek-ai', 'dsh')
+    const entry = join(packageRoot, 'lib', 'bin.js')
+    mkdirSync(join(packageRoot, 'lib'), { recursive: true })
+    writeFileSync(join(prefix, 'dsh.cmd'), '@echo off\r\n')
+    writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh',
+      bin: 'lib/bin.js',
+    }))
+    writeFileSync(entry, '')
+
+    expect(resolveLaunch('/not/a/source/tree', join(prefix, 'dsh.cmd'), ['web'], {
+      platform: 'win32',
+      execPath: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      env: {},
+    })).toEqual({
+      command: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      args: [entry, 'web'],
+      sourceCheckout: false,
+      env: { ELECTRON_RUN_AS_NODE: '1' },
+    })
+  })
 })

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -58,8 +58,10 @@ describe('DSH launch resolution', () => {
     const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-prefix-'))
     const packageRoot = join(prefix, 'node_modules', '@deepseek-ai', 'dsh')
     const entry = join(packageRoot, 'lib', 'bin.js')
+    const node = join(prefix, 'node.exe')
     mkdirSync(join(packageRoot, 'lib'), { recursive: true })
     writeFileSync(join(prefix, 'dsh.cmd'), '@echo off\r\n')
+    writeFileSync(node, '')
     writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
       name: '@deepseek-ai/dsh',
       bin: { dsh: 'lib/bin.js' },
@@ -68,13 +70,36 @@ describe('DSH launch resolution', () => {
 
     expect(resolveLaunch('/not/a/source/tree', '', ['web', '--port', '0'], {
       platform: 'win32',
-      execPath: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
       env: { Path: prefix },
     })).toEqual({
-      command: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      command: node,
       args: [entry, 'web', '--port', '0'],
       sourceCheckout: false,
-      env: { ELECTRON_RUN_AS_NODE: '1' },
+    })
+  })
+
+  it('uses the Node runtime that npm shims would resolve from PATH', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-prefix-'))
+    const nodeDirectory = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-node-'))
+    const packageRoot = join(prefix, 'node_modules', '@deepseek-ai', 'dsh')
+    const entry = join(packageRoot, 'lib', 'bin.js')
+    const node = join(nodeDirectory, 'node.exe')
+    mkdirSync(join(packageRoot, 'lib'), { recursive: true })
+    writeFileSync(join(prefix, 'dsh.cmd'), '@echo off\r\n')
+    writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh',
+      bin: { dsh: 'lib/bin.js' },
+    }))
+    writeFileSync(entry, '')
+    writeFileSync(node, '')
+
+    expect(resolveLaunch('/not/a/source/tree', '', ['web'], {
+      platform: 'win32',
+      env: { Path: `${prefix};${nodeDirectory}` },
+    })).toEqual({
+      command: node,
+      args: [entry, 'web'],
+      sourceCheckout: false,
     })
   })
 
@@ -82,7 +107,6 @@ describe('DSH launch resolution', () => {
     const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-missing-'))
     expect(resolveLaunch('/not/a/source/tree', '', ['web'], {
       platform: 'win32',
-      execPath: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
       env: { Path: prefix },
     })).toEqual({
       command: 'dsh.cmd',
@@ -95,8 +119,10 @@ describe('DSH launch resolution', () => {
     const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-explicit-'))
     const packageRoot = join(prefix, 'node_modules', '@deepseek-ai', 'dsh')
     const entry = join(packageRoot, 'lib', 'bin.js')
+    const node = join(prefix, 'node.exe')
     mkdirSync(join(packageRoot, 'lib'), { recursive: true })
     writeFileSync(join(prefix, 'dsh.cmd'), '@echo off\r\n')
+    writeFileSync(node, '')
     writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
       name: '@deepseek-ai/dsh',
       bin: 'lib/bin.js',
@@ -105,13 +131,11 @@ describe('DSH launch resolution', () => {
 
     expect(resolveLaunch('/not/a/source/tree', join(prefix, 'dsh.cmd'), ['web'], {
       platform: 'win32',
-      execPath: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
       env: {},
     })).toEqual({
-      command: 'C:\\Program Files\\Microsoft VS Code\\Code.exe',
+      command: node,
       args: [entry, 'web'],
       sourceCheckout: false,
-      env: { ELECTRON_RUN_AS_NODE: '1' },
     })
   })
 })

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -138,4 +138,34 @@ describe('DSH launch resolution', () => {
       sourceCheckout: false,
     })
   })
+
+  it('resolves an explicitly configured relative dsh.cmd from the launch cwd', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-workspace-'))
+    const relativePrefix = join(workspace, 'tools')
+    const globalPrefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-global-'))
+    const relativePackage = join(relativePrefix, 'node_modules', '@deepseek-ai', 'dsh')
+    const globalPackage = join(globalPrefix, 'node_modules', '@deepseek-ai', 'dsh')
+    const relativeEntry = join(relativePackage, 'lib', 'bin.js')
+    mkdirSync(join(relativePackage, 'lib'), { recursive: true })
+    mkdirSync(join(globalPackage, 'lib'), { recursive: true })
+    for (const [prefix, packageRoot] of [[relativePrefix, relativePackage], [globalPrefix, globalPackage]]) {
+      writeFileSync(join(prefix, 'dsh.cmd'), '@echo off\r\n')
+      writeFileSync(join(prefix, 'node.exe'), '')
+      writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+        name: '@deepseek-ai/dsh',
+        bin: { dsh: 'lib/bin.js' },
+      }))
+      writeFileSync(join(packageRoot, 'lib', 'bin.js'), '')
+    }
+
+    expect(resolveLaunch('/not/a/source/tree', 'tools\\dsh.cmd', ['web'], {
+      platform: 'win32',
+      cwd: workspace,
+      env: { Path: globalPrefix },
+    })).toEqual({
+      command: join(relativePrefix, 'node.exe'),
+      args: [relativeEntry, 'web'],
+      sourceCheckout: false,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Resolve the npm-generated `dsh.cmd` shim to the official DSH JavaScript entry point on Windows
- Launch DSH through VS Code's bundled Node runtime without `shell: true`
- Apply the fix to both the DSH runtime and plugin management commands
- Support both PATH-based discovery and explicitly configured `dsh.cmd` paths

## Testing

- `pnpm check`
- 74 tests passed

Fixes #2