### PR TITLE
feat: support DSH rc.8

### DIFF
--- a/src/dsh-client.ts
+++ b/src/dsh-client.ts
@@ -28,7 +28,7 @@ export interface ModelSelection {
 export interface CommandDescriptor {
   name: string
   description: string
-  input?: { hint: string }
+  input?: { hint: string; images?: boolean }
 }
 
 export interface CommandExecution {
@@ -257,8 +257,24 @@ export class DshClient {
     return this.call('agentPreset.select', { sessionId, agentPreset }, 30_000)
   }
 
-  executeCommand(sessionId: string, line: string): Promise<CommandExecution | undefined> {
-    return this.call('commands/execute', { args: { agentId: sessionId, line } }, 300_000)
+  executeCommand(
+    sessionId: string,
+    line: string,
+    images?: readonly PromptImage[],
+  ): Promise<CommandExecution | undefined> {
+    return this.call('commands/execute', {
+      args: {
+        agentId: sessionId,
+        line,
+        ...(images === undefined ? {} : {
+          images: images.map(image => ({
+            mediaType: image.mediaType,
+            data: image.data,
+            ...(image.name === undefined ? {} : { name: image.name }),
+          })),
+        }),
+      },
+    }, 300_000)
   }
 
   dispose(): void {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -350,9 +350,20 @@ class DshChatController implements vscode.Disposable {
     if ((normalized === '' && images.length === 0) || this._state.sessionId === '') return
     const slash = this.slashRoute(normalized)
     if (slash.kind === 'command') {
-      if (images.length > 0) throw new Error('DeepSeek commands cannot include image attachments.')
-      const execution = await this.requireClient().executeCommand(this._state.sessionId, normalized)
+      const command = this._state.commands.find(item => item.name === slash.name)
+      if (images.length > 0 && command?.input?.images !== true) {
+        throw new Error(`${slash.token} does not accept image attachments; remove them first.`)
+      }
+      const usesRc8Envelope = this._state.commands.some(item => item.input?.images === true)
+      const execution = await this.requireClient().executeCommand(
+        this._state.sessionId,
+        normalized,
+        usesRc8Envelope ? images : undefined,
+      )
       if (execution === undefined) throw new Error(`DeepSeek did not recognize ${slash.token}.`)
+      if (images.length > 0 && execution.result.kind === 'error') {
+        throw new Error(execution.result.text ?? `${slash.token} could not use the attached images.`)
+      }
       return
     }
     if (slash.kind === 'unknown') throw new Error(`Unknown DeepSeek command or skill: ${slash.token}`)

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -12,6 +12,26 @@ export interface LaunchCommand {
 
 const SOURCE_ROOT_PACKAGE = '@deepseek-ai/dsh-root'
 
+function supportsNoOpen(version: string): boolean {
+  const match = /(?:^|\s)(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?(?:\s|$)/.exec(version)
+  if (match === null) return false
+  const major = Number(match[1])
+  const minor = Number(match[2])
+  const patch = Number(match[3])
+  const rc = match[4] === undefined ? undefined : Number(match[4])
+  if (major !== 0) return major > 0
+  if (minor !== 1) return minor > 1
+  if (patch !== 0) return patch > 0
+  return rc === undefined || rc >= 8
+}
+
+/** Keep the extension-owned Web Host from opening a second, unused UI on rc.8+. */
+export function webArgsForDshVersion(args: readonly string[], version: string | undefined): string[] {
+  const webProfile = args[0] === 'web' || (args[0] === '--profile' && args[1] === 'web')
+  if (!webProfile || args.includes('--no-open') || version === undefined || !supportsNoOpen(version)) return [...args]
+  return [...args, '--no-open']
+}
+
 function resolveTsxImport(sourceRoot: string): string {
   try {
     const require = createRequire(join(sourceRoot, 'package.json'))

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import * as vscode from 'vscode'
 import { DEEPSEEK_API_KEY_SECRET } from './credentials.js'
-import { parseDshWebUrl, resolveLaunch } from './launch.js'
+import { parseDshWebUrl, resolveLaunch, type LaunchCommand, webArgsForDshVersion } from './launch.js'
 
 export type RuntimeState =
   | { kind: 'stopped' }
@@ -23,6 +23,42 @@ function deferredStart(): PendingStart {
     reject = fail
   })
   return { resolve, reject, promise }
+}
+
+function readDshVersion(launch: LaunchCommand, cwd: string): Promise<string | undefined> {
+  return new Promise(resolve => {
+    let settled = false
+    let output = ''
+    let timer: NodeJS.Timeout | undefined
+    const finish = (version?: string): void => {
+      if (settled) return
+      settled = true
+      if (timer !== undefined) clearTimeout(timer)
+      resolve(version)
+    }
+    let child: ChildProcessWithoutNullStreams
+    try {
+      child = spawn(launch.command, launch.args, {
+        cwd,
+        env: { ...process.env, NO_COLOR: '1', ...launch.env },
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      })
+    } catch {
+      finish()
+      return
+    }
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => { output += chunk })
+    child.stderr.on('data', (chunk: string) => { output += chunk })
+    child.on('error', () => { finish() })
+    child.on('exit', code => { finish(code === 0 ? output.trim() : undefined) })
+    timer = setTimeout(() => {
+      child.kill()
+      finish()
+    }, 5_000)
+  })
 }
 
 /** Owns exactly one official DSH child process for the current Extension Host. */
@@ -67,8 +103,11 @@ export class DshRuntime implements vscode.Disposable {
 
     const config = vscode.workspace.getConfiguration('deepseekHarness', workspace)
     const configuredExecutable = config.get<string>('executable', '')
-    const args = config.get<string[]>('arguments', ['web', '--host', '127.0.0.1', '--port', '0'])
+    const configuredArgs = config.get<string[]>('arguments', ['web', '--host', '127.0.0.1', '--port', '0'])
     const timeoutMs = config.get<number>('startupTimeout', 60_000)
+    const versionLaunch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, ['--version'])
+    const version = await readDshVersion(versionLaunch, workspace.fsPath)
+    const args = webArgsForDshVersion(configuredArgs, version)
     const launch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, args)
     const storedApiKey = await this.context.secrets.get(DEEPSEEK_API_KEY_SECRET)
 
@@ -78,6 +117,7 @@ export class DshRuntime implements vscode.Disposable {
     this.stopping = false
     const renderedCommand = [launch.command, ...launch.args].map(part => JSON.stringify(part)).join(' ')
     this.output.appendLine(`[runtime] cwd: ${workspace.fsPath}`)
+    if (version !== undefined) this.output.appendLine(`[runtime] DSH version: ${version}`)
     this.output.appendLine(`[runtime] launch: ${renderedCommand}`)
     if (storedApiKey !== undefined) this.output.appendLine('[runtime] DeepSeek credential: VS Code SecretStorage')
     this.publish({

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -105,20 +105,31 @@ export class DshRuntime implements vscode.Disposable {
     const configuredExecutable = config.get<string>('executable', '')
     const configuredArgs = config.get<string[]>('arguments', ['web', '--host', '127.0.0.1', '--port', '0'])
     const timeoutMs = config.get<number>('startupTimeout', 60_000)
-    const versionLaunch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, ['--version'], {
-      cwd: workspace.fsPath,
-    })
-    const version = await readDshVersion(versionLaunch, workspace.fsPath)
-    const args = webArgsForDshVersion(configuredArgs, version)
-    const launch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, args, {
-      cwd: workspace.fsPath,
-    })
-    const storedApiKey = await this.context.secrets.get(DEEPSEEK_API_KEY_SECRET)
-
     const pending = deferredStart()
     this.pending = pending
     this.stdoutBuffer = ''
     this.stopping = false
+
+    let launch: LaunchCommand
+    let version: string | undefined
+    let storedApiKey: string | undefined
+    try {
+      const versionLaunch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, ['--version'], {
+        cwd: workspace.fsPath,
+      })
+      version = await readDshVersion(versionLaunch, workspace.fsPath)
+      if (this.pending !== pending) return pending.promise
+      const args = webArgsForDshVersion(configuredArgs, version)
+      launch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, args, {
+        cwd: workspace.fsPath,
+      })
+      storedApiKey = await this.context.secrets.get(DEEPSEEK_API_KEY_SECRET)
+      if (this.pending !== pending) return pending.promise
+    } catch (error) {
+      this.failStart(error instanceof Error ? error : new Error(String(error)), pending)
+      return pending.promise
+    }
+
     const renderedCommand = [launch.command, ...launch.args].map(part => JSON.stringify(part)).join(' ')
     this.output.appendLine(`[runtime] cwd: ${workspace.fsPath}`)
     if (version !== undefined) this.output.appendLine(`[runtime] DSH version: ${version}`)
@@ -143,7 +154,7 @@ export class DshRuntime implements vscode.Disposable {
         windowsHide: true,
       })
     } catch (error) {
-      this.failStart(error instanceof Error ? error : new Error(String(error)))
+      this.failStart(error instanceof Error ? error : new Error(String(error)), pending)
       return pending.promise
     }
     this.child = child
@@ -154,7 +165,7 @@ export class DshRuntime implements vscode.Disposable {
     child.stderr.on('data', (chunk: string) => { this.output.append(chunk) })
     child.on('error', (error) => {
       if (child.pid === undefined) this.child = undefined
-      this.failStart(error)
+      this.failStart(error, pending)
     })
     child.on('exit', (code, signal) => {
       this.clearStartupTimer()
@@ -166,14 +177,14 @@ export class DshRuntime implements vscode.Disposable {
         return
       }
       if (this.pending !== undefined) {
-        this.failStart(new Error(detail))
+        this.failStart(new Error(detail), pending)
       } else {
         this.publish({ kind: 'failed', message: detail })
       }
     })
 
     this.startupTimer = setTimeout(() => {
-      this.failStart(new Error(`DSH did not report a web URL within ${String(timeoutMs)} ms.`))
+      this.failStart(new Error(`DSH did not report a web URL within ${String(timeoutMs)} ms.`), pending)
       void this.stop()
     }, timeoutMs)
 
@@ -204,12 +215,8 @@ export class DshRuntime implements vscode.Disposable {
     pending.resolve(localUri)
   }
 
-  private failStart(error: Error): void {
-    const pending = this.pending
-    if (pending === undefined) {
-      if (!this.stopping) this.publish({ kind: 'failed', message: error.message })
-      return
-    }
+  private failStart(error: Error, pending: PendingStart): void {
+    if (this.pending !== pending) return
     this.pending = undefined
     this.clearStartupTimer()
     this.publish({ kind: 'failed', message: error.message })

--- a/tests/dsh-client.spec.ts
+++ b/tests/dsh-client.spec.ts
@@ -167,4 +167,45 @@ describe('DshClient queue protocol', () => {
       { method: 'session.history', payload: { sessionId: 'session-1', beforeSeq: 42, maxMessages: 100 } },
     ])
   })
+
+  it('uses the rc.8 command image envelope without breaking legacy command calls', async () => {
+    const requests: Array<{ method: string; payload: unknown }> = []
+    vi.stubGlobal('fetch', vi.fn(async (_url: URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { rpcId: string; method: string; payload: unknown }
+      requests.push({ method: request.method, payload: request.payload })
+      return new Response(JSON.stringify({
+        type: 'server-response', rpcId: request.rpcId,
+        result: {
+          ok: true,
+          value: { commandId: 'command-1', result: { kind: 'success' } },
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }))
+    const client = new DshClient(new URL('http://127.0.0.1:31415'))
+
+    await client.executeCommand('session-1', '/compact')
+    await client.executeCommand('session-1', '/plan inspect this', [{
+      type: 'image',
+      mediaType: 'image/png',
+      data: 'YWJj',
+      name: 'diagram.png',
+    }])
+
+    expect(requests).toEqual([
+      {
+        method: 'commands/execute',
+        payload: { args: { agentId: 'session-1', line: '/compact' } },
+      },
+      {
+        method: 'commands/execute',
+        payload: {
+          args: {
+            agentId: 'session-1',
+            line: '/plan inspect this',
+            images: [{ mediaType: 'image/png', data: 'YWJj', name: 'diagram.png' }],
+          },
+        },
+      },
+    ])
+  })
 })

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { findSourceRoot, parseDshWebUrl, resolveLaunch } from '../src/launch.ts'
+import { findSourceRoot, parseDshWebUrl, resolveLaunch, webArgsForDshVersion } from '../src/launch.ts'
 
 describe('DSH launch resolution', () => {
   it('recognizes only the official web URL announcement', () => {
@@ -10,6 +10,16 @@ describe('DSH launch resolution', () => {
     expect(parseDshWebUrl('info dsh web: http://127.0.0.1:8080 (LAN: ignored)')).toBe('http://127.0.0.1:8080')
     expect(parseDshWebUrl('server listening at http://127.0.0.1:43127')).toBeUndefined()
     expect(parseDshWebUrl('dsh web: https://example.com')).toBeUndefined()
+  })
+
+  it('suppresses the rc.8 browser handoff while preserving older DSH launches', () => {
+    const args = ['web', '--host', '127.0.0.1', '--port', '0']
+    expect(webArgsForDshVersion(args, '0.1.0-rc.7')).toEqual(args)
+    expect(webArgsForDshVersion(args, '0.1.0-rc.8')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(args, '0.1.0')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion([...args, '--no-open'], '0.1.0-rc.8')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(['--profile', 'web', '--port', '0'], 'dsh 0.1.0-rc.8'))
+      .toEqual(['--profile', 'web', '--port', '0', '--no-open'])
   })
 
   it('finds the official source checkout and launches its real CLI entry', () => {


### PR DESCRIPTION
## Summary

- Adapt slash commands to the rc.8 image attachment envelope
- Support images for `/plan`, `/goal`, and other compatible commands
- Prevent the extension-owned DSH runtime from opening an extra browser window
- Preserve compatibility with earlier DSH releases

## Testing

- `pnpm check`