### PR TITLE
fix: prevent long chat output from freezing VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,11 +165,13 @@
       "properties": {
         "deepseekHarness.executable": {
           "type": "string",
+          "scope": "resource",
           "default": "",
           "markdownDescription": "DSH executable. Leave empty to use a source checkout when nested inside deepseek-harness, otherwise `dsh` from PATH."
         },
         "deepseekHarness.arguments": {
           "type": "array",
+          "scope": "resource",
           "items": {
             "type": "string"
           },
@@ -189,11 +191,13 @@
         },
         "deepseekHarness.reuseExistingRuntime": {
           "type": "boolean",
+          "scope": "resource",
           "default": true,
           "description": "Reuse a healthy official DSH Web runtime on 127.0.0.1:3080 when no custom executable or arguments are configured."
         },
         "deepseekHarness.startupTimeout": {
           "type": "number",
+          "scope": "resource",
           "default": 60000,
           "minimum": 1000,
           "maximum": 300000,

--- a/src/chat-state-patch.ts
+++ b/src/chat-state-patch.ts
@@ -1,4 +1,6 @@
-import type { ConversationImage, ConversationMessage } from './conversation.js'
+import { assistantStreamAppend, type ConversationImage, type ConversationMessage } from './conversation.js'
+
+export const WEBVIEW_INLINE_CHAR_LIMIT = 20_000
 
 export interface ConversationMessagesPatch {
   reset?: ConversationMessage[]
@@ -21,26 +23,39 @@ function compactToolView(value: unknown): unknown {
   return Object.keys(compact).length === 0 ? undefined : compact
 }
 
-/** Keeps completed tool cards lightweight until their body is expanded. */
+function bodyRevision(message: ConversationMessage): string {
+  const images = (message.images ?? []).map(image => `${image.attachmentId}:${image.data?.length ?? 0}:${image.error ?? ''}`).join('|')
+  return `${message.streaming === true ? 'streaming' : 'settled'}:${message.text.length}:${message.rawInput?.length ?? 0}:${message.rawResult?.length ?? 0}:${images}`
+}
+
+/** Keeps large or structured message bodies lightweight until they are displayed. */
 export function messageForWebview(message: ConversationMessage): ConversationMessage {
-  if (message.role !== 'tool' || message.streaming === true || message.deferredBody === true) return message
-  const hasBody = message.callView !== undefined
+  if (message.deferredBody === true) return message
+  const hasToolBody = message.role === 'tool' && (message.callView !== undefined
     || message.resultView !== undefined
     || message.rawInput !== undefined
     || message.rawResult !== undefined
-    || (message.images?.length ?? 0) > 0
-  if (!hasBody) return message
+    || (message.images?.length ?? 0) > 0)
+  const hasLargeCommandBody = message.role === 'command' && (message.rawResult?.length ?? 0) > WEBVIEW_INLINE_CHAR_LIMIT
+  const hasLargeAssistantBody = message.role === 'assistant'
+    && message.streaming !== true
+    && (message.text.length > WEBVIEW_INLINE_CHAR_LIMIT || (message.images?.some(image => image.data !== undefined) ?? false))
+  if (!hasToolBody && !hasLargeCommandBody && !hasLargeAssistantBody) return message
   const callView = compactToolView(message.callView)
   const resultView = compactToolView(message.resultView)
   return {
     id: message.id,
     role: message.role,
-    text: message.text,
+    text: hasLargeAssistantBody ? '' : message.text,
     ...(message.detail === undefined ? {} : { detail: message.detail }),
     ...(message.failed === undefined ? {} : { failed: message.failed }),
     ...(callView === undefined ? {} : { callView }),
     ...(resultView === undefined ? {} : { resultView }),
     deferredBody: true,
+    deferredBodyRevision: bodyRevision(message),
+    ...(message.role === 'assistant'
+      ? { bodyLength: message.text.length }
+      : message.rawResult === undefined ? {} : { bodyLength: message.rawResult.length }),
   }
 }
 
@@ -83,15 +98,16 @@ function sameMessage(left: ConversationMessage, right: ConversationMessage): boo
     && left.rawInput === right.rawInput
     && left.rawResult === right.rawResult
     && left.deferredBody === right.deferredBody
+    && left.deferredBodyRevision === right.deferredBodyRevision
+    && left.bodyLength === right.bodyLength
     && sameImages(left.images, right.images)
 }
 
-function canAppendAssistantText(left: ConversationMessage, right: ConversationMessage): boolean {
-  return left.id === right.id
+function appendedAssistantText(left: ConversationMessage, right: ConversationMessage): string | undefined {
+  const compatible = left.id === right.id
     && left.role === 'assistant'
     && right.role === 'assistant'
     && left.streaming === true
-    && right.text.startsWith(left.text)
     && left.detail === right.detail
     && left.failed === right.failed
     && left.callView === right.callView
@@ -100,6 +116,10 @@ function canAppendAssistantText(left: ConversationMessage, right: ConversationMe
     && left.rawResult === right.rawResult
     && left.deferredBody === right.deferredBody
     && sameImages(left.images, right.images)
+  if (!compatible) return undefined
+  const projected = assistantStreamAppend(left, right)
+  if (projected !== undefined) return projected
+  return right.text.startsWith(left.text) ? right.text.slice(left.text.length) : undefined
 }
 
 /**
@@ -127,10 +147,11 @@ export function diffConversationMessages(
       continue
     }
     if (sameMessage(current, message)) continue
-    if (canAppendAssistantText(current, message)) {
+    const appendedText = appendedAssistantText(current, message)
+    if (appendedText !== undefined) {
       appends.push({
         id: message.id,
-        text: message.text.slice(current.text.length),
+        text: appendedText,
         streaming: message.streaming === true,
       })
     } else {

--- a/src/chat-state-patch.ts
+++ b/src/chat-state-patch.ts
@@ -5,6 +5,45 @@ export interface ConversationMessagesPatch {
   upserts?: ConversationMessage[]
 }
 
+function compactToolView(value: unknown): unknown {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
+  const source = value as Record<string, unknown>
+  const compact: Record<string, unknown> = {}
+  if (typeof source.card === 'string') compact.card = source.card
+  if (typeof source.title === 'string') compact.title = source.title
+  return Object.keys(compact).length === 0 ? undefined : compact
+}
+
+/** Keeps completed tool cards lightweight until their body is expanded. */
+export function messageForWebview(message: ConversationMessage): ConversationMessage {
+  if (message.role !== 'tool' || message.streaming === true || message.deferredBody === true) return message
+  const hasBody = message.callView !== undefined
+    || message.resultView !== undefined
+    || message.rawInput !== undefined
+    || message.rawResult !== undefined
+    || (message.images?.length ?? 0) > 0
+  if (!hasBody) return message
+  const callView = compactToolView(message.callView)
+  const resultView = compactToolView(message.resultView)
+  return {
+    id: message.id,
+    role: message.role,
+    text: message.text,
+    ...(message.detail === undefined ? {} : { detail: message.detail }),
+    ...(message.failed === undefined ? {} : { failed: message.failed }),
+    ...(callView === undefined ? {} : { callView }),
+    ...(resultView === undefined ? {} : { resultView }),
+    deferredBody: true,
+  }
+}
+
+export function messagesPatchForWebview(patch: ConversationMessagesPatch): ConversationMessagesPatch {
+  return {
+    ...(patch.reset === undefined ? {} : { reset: patch.reset.map(messageForWebview) }),
+    ...(patch.upserts === undefined ? {} : { upserts: patch.upserts.map(messageForWebview) }),
+  }
+}
+
 function sameImage(left: ConversationImage, right: ConversationImage): boolean {
   return left.attachmentId === right.attachmentId
     && left.mediaType === right.mediaType
@@ -35,6 +74,7 @@ function sameMessage(left: ConversationMessage, right: ConversationMessage): boo
     && left.resultView === right.resultView
     && left.rawInput === right.rawInput
     && left.rawResult === right.rawResult
+    && left.deferredBody === right.deferredBody
     && sameImages(left.images, right.images)
 }
 

--- a/src/chat-state-patch.ts
+++ b/src/chat-state-patch.ts
@@ -3,6 +3,13 @@ import type { ConversationImage, ConversationMessage } from './conversation.js'
 export interface ConversationMessagesPatch {
   reset?: ConversationMessage[]
   upserts?: ConversationMessage[]
+  appends?: ConversationMessageAppend[]
+}
+
+export interface ConversationMessageAppend {
+  id: string
+  text: string
+  streaming: boolean
 }
 
 function compactToolView(value: unknown): unknown {
@@ -41,6 +48,7 @@ export function messagesPatchForWebview(patch: ConversationMessagesPatch): Conve
   return {
     ...(patch.reset === undefined ? {} : { reset: patch.reset.map(messageForWebview) }),
     ...(patch.upserts === undefined ? {} : { upserts: patch.upserts.map(messageForWebview) }),
+    ...(patch.appends === undefined ? {} : { appends: patch.appends }),
   }
 }
 
@@ -78,6 +86,22 @@ function sameMessage(left: ConversationMessage, right: ConversationMessage): boo
     && sameImages(left.images, right.images)
 }
 
+function canAppendAssistantText(left: ConversationMessage, right: ConversationMessage): boolean {
+  return left.id === right.id
+    && left.role === 'assistant'
+    && right.role === 'assistant'
+    && left.streaming === true
+    && right.text.startsWith(left.text)
+    && left.detail === right.detail
+    && left.failed === right.failed
+    && left.callView === right.callView
+    && left.resultView === right.resultView
+    && left.rawInput === right.rawInput
+    && left.rawResult === right.rawResult
+    && left.deferredBody === right.deferredBody
+    && sameImages(left.images, right.images)
+}
+
 /**
  * Produces an append/update patch for the common streaming path. History
  * insertion, removal, and reordering intentionally fall back to a reset.
@@ -93,11 +117,30 @@ export function diffConversationMessages(
   if (next.length < previous.length) return { reset: [...next] }
 
   const upserts: ConversationMessage[] = []
+  const appends: ConversationMessageAppend[] = []
   for (let index = 0; index < next.length; index += 1) {
     const message = next[index]
     if (message === undefined) continue
     const current = previous[index]
-    if (current === undefined || !sameMessage(current, message)) upserts.push(message)
+    if (current === undefined) {
+      upserts.push(message)
+      continue
+    }
+    if (sameMessage(current, message)) continue
+    if (canAppendAssistantText(current, message)) {
+      appends.push({
+        id: message.id,
+        text: message.text.slice(current.text.length),
+        streaming: message.streaming === true,
+      })
+    } else {
+      upserts.push(message)
+    }
   }
-  return upserts.length === 0 ? undefined : { upserts }
+  return upserts.length === 0 && appends.length === 0
+    ? undefined
+    : {
+        ...(upserts.length === 0 ? {} : { upserts }),
+        ...(appends.length === 0 ? {} : { appends }),
+      }
 }

--- a/src/chat-state-patch.ts
+++ b/src/chat-state-patch.ts
@@ -1,0 +1,63 @@
+import type { ConversationImage, ConversationMessage } from './conversation.js'
+
+export interface ConversationMessagesPatch {
+  reset?: ConversationMessage[]
+  upserts?: ConversationMessage[]
+}
+
+function sameImage(left: ConversationImage, right: ConversationImage): boolean {
+  return left.attachmentId === right.attachmentId
+    && left.mediaType === right.mediaType
+    && left.width === right.width
+    && left.height === right.height
+    && left.name === right.name
+    && left.data === right.data
+    && left.error === right.error
+}
+
+function sameImages(left: readonly ConversationImage[] | undefined, right: readonly ConversationImage[] | undefined): boolean {
+  if (left === right) return true
+  if (left === undefined || right === undefined || left.length !== right.length) return false
+  return left.every((image, index) => {
+    const candidate = right[index]
+    return candidate !== undefined && sameImage(image, candidate)
+  })
+}
+
+function sameMessage(left: ConversationMessage, right: ConversationMessage): boolean {
+  return left.id === right.id
+    && left.role === right.role
+    && left.text === right.text
+    && left.detail === right.detail
+    && left.streaming === right.streaming
+    && left.failed === right.failed
+    && left.callView === right.callView
+    && left.resultView === right.resultView
+    && left.rawInput === right.rawInput
+    && left.rawResult === right.rawResult
+    && sameImages(left.images, right.images)
+}
+
+/**
+ * Produces an append/update patch for the common streaming path. History
+ * insertion, removal, and reordering intentionally fall back to a reset.
+ */
+export function diffConversationMessages(
+  previous: readonly ConversationMessage[],
+  next: readonly ConversationMessage[],
+): ConversationMessagesPatch | undefined {
+  const sharedLength = Math.min(previous.length, next.length)
+  for (let index = 0; index < sharedLength; index += 1) {
+    if (previous[index]?.id !== next[index]?.id) return { reset: [...next] }
+  }
+  if (next.length < previous.length) return { reset: [...next] }
+
+  const upserts: ConversationMessage[] = []
+  for (let index = 0; index < next.length; index += 1) {
+    const message = next[index]
+    if (message === undefined) continue
+    const current = previous[index]
+    if (current === undefined || !sameMessage(current, message)) upserts.push(message)
+  }
+  return upserts.length === 0 ? undefined : { upserts }
+}

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -16,6 +16,40 @@ export interface ConversationMessage {
   rawResult?: string
   images?: ConversationImage[]
   deferredBody?: boolean
+  deferredBodyRevision?: string
+  bodyLength?: number
+}
+
+interface AssistantStreamNode {
+  previous?: AssistantStreamNode
+  text: string
+}
+
+const assistantStreams = new WeakMap<ConversationMessage, AssistantStreamNode>()
+
+function inheritAssistantStream(source: ConversationMessage | undefined, target: ConversationMessage): void {
+  const stream = source === undefined ? undefined : assistantStreams.get(source)
+  if (stream !== undefined) assistantStreams.set(target, stream)
+}
+
+function appendAssistantStream(source: ConversationMessage | undefined, target: ConversationMessage, text: string): void {
+  const previous = source === undefined ? undefined : assistantStreams.get(source)
+  assistantStreams.set(target, { ...(previous === undefined ? {} : { previous }), text })
+}
+
+/** Returns the exact append represented by two projector snapshots without rescanning their accumulated text. */
+export function assistantStreamAppend(left: ConversationMessage, right: ConversationMessage): string | undefined {
+  const target = assistantStreams.get(left)
+  let current = assistantStreams.get(right)
+  if (current === undefined) return undefined
+  if (current === target) return left.text.length === right.text.length ? '' : undefined
+  const chunks: string[] = []
+  while (current !== undefined && current !== target) {
+    chunks.push(current.text)
+    current = current.previous
+  }
+  if (current !== target) return undefined
+  return chunks.reverse().join('')
 }
 
 export interface ConversationImage {
@@ -141,31 +175,40 @@ export class ConversationProjector {
       if (chunk?.type === 'block-end') {
         const images = imageContent(chunk.block)
         if (images.length === 0) return
-        this.set(id, {
+        const next: ConversationMessage = {
           id,
           role: 'assistant',
           text: current?.text ?? '',
           images: mergeImages(current?.images, images),
           streaming: true,
-        })
+        }
+        inheritAssistantStream(current, next)
+        this.set(id, next)
         return
       }
       if (chunk?.type !== 'text-delta' || typeof chunk.text !== 'string') return
-      this.set(id, {
+      const next: ConversationMessage = {
         id,
         role: 'assistant',
         text: `${current?.text ?? ''}${chunk.text}`,
         streaming: true,
-      })
+      }
+      appendAssistantStream(current, next, chunk.text)
+      this.set(id, next)
       return
     }
 
     if (event.type === 'assistant/message') {
       const message = record(data.message)
       const id = `assistant:${String(data.turn)}:${String(data.step)}`
+      const current = this.byId.get(id)
       const text = textContent(message?.content)
       const images = imageContent(message?.content)
-      if (text !== '' || images.length > 0) this.set(id, { id, role: 'assistant', text, ...(images.length > 0 ? { images } : {}) })
+      if (text !== '' || images.length > 0) {
+        const next: ConversationMessage = { id, role: 'assistant', text, ...(images.length > 0 ? { images } : {}) }
+        if (current !== undefined && text === current.text) inheritAssistantStream(current, next)
+        this.set(id, next)
+      }
       return
     }
 
@@ -259,7 +302,10 @@ export class ConversationProjector {
   messages(): ConversationMessage[] {
     return this.orderedIds.flatMap(id => {
       const value = this.byId.get(id)
-      return value === undefined ? [] : [{ ...value }]
+      if (value === undefined) return []
+      const copy = { ...value }
+      inheritAssistantStream(value, copy)
+      return [copy]
     })
   }
 

--- a/src/conversation.ts
+++ b/src/conversation.ts
@@ -15,6 +15,7 @@ export interface ConversationMessage {
   rawInput?: string
   rawResult?: string
   images?: ConversationImage[]
+  deferredBody?: boolean
 }
 
 export interface ConversationImage {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ import { jobsSnapshotOf, type JobItem } from './jobs.js'
 import { queueSnapshotOf, type QueueItemState } from './queue.js'
 import { DshRuntime, type RuntimeOwnership, type RuntimeState } from './runtime.js'
 import { toolWriteIntents } from './tool-write-guard.js'
-import { pageToolOutput } from './tool-output-page.js'
+import { pageConversationMessage } from './tool-output-page.js'
 import { chatHtml } from './webview.js'
 import { DshPluginManager } from './plugin-manager.js'
 import type { PluginInventorySnapshot } from './plugin-profile.js'
@@ -1194,7 +1194,7 @@ class DshSurface implements vscode.Disposable {
             const sessionId = this.controller.state.sessionId
             const requestedSessionId = typeof value.sessionId === 'string' ? value.sessionId : ''
             const message = requestedSessionId === sessionId
-              ? this.controller.state.messages.find(candidate => candidate.id === value.messageId && candidate.role === 'tool')
+              ? this.controller.state.messages.find(candidate => candidate.id === value.messageId)
               : undefined
             await this.webview.postMessage({
               type: 'tool-output',
@@ -1203,7 +1203,7 @@ class DshSurface implements vscode.Disposable {
               requestId: value.requestId,
               ...(message === undefined
                 ? { error: requestedSessionId === sessionId ? 'Tool output is no longer available.' : 'The conversation changed before this output loaded.' }
-                : { page: pageToolOutput(message, typeof value.cursor === 'string' ? value.cursor : undefined) }),
+                : { page: pageConversationMessage(message, typeof value.cursor === 'string' ? value.cursor : undefined) }),
             })
           }
           return

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,7 @@ import type { SettingsDescription, SettingsMutation, SettingsNamespace } from '.
 import { earliestHistorySequence, mergeHistoryEntries, unseenHistoryEntries } from './history.js'
 import { routeSlashInput, type SlashRoute } from './slash-routing.js'
 import { unavailableUsageMeterState, usageMeterStateOf, type UsageMeterState } from './usage-meter.js'
+import { diffConversationMessages, type ConversationMessagesPatch } from './chat-state-patch.js'
 
 let activeRuntime: DshRuntime | undefined
 
@@ -132,6 +133,25 @@ interface ChatViewState {
   jobs: JobItem[]
   hasMoreHistory: boolean
   loadingHistory: boolean
+}
+
+interface ChatViewStateUpdate {
+  patch: Partial<Omit<ChatViewState, 'messages'>>
+  messages?: ConversationMessagesPatch
+}
+
+function stateUpdate(previous: ChatViewState, next: ChatViewState): ChatViewStateUpdate | undefined {
+  const patch: Partial<Omit<ChatViewState, 'messages'>> = {}
+  const previousRecord = previous as unknown as Record<string, unknown>
+  const nextRecord = next as unknown as Record<string, unknown>
+  const patchRecord = patch as Record<string, unknown>
+  for (const key of Object.keys(nextRecord)) {
+    if (key !== 'messages' && previousRecord[key] !== nextRecord[key]) patchRecord[key] = nextRecord[key]
+  }
+  const messages = diffConversationMessages(previous.messages, next.messages)
+  return Object.keys(patchRecord).length === 0 && messages === undefined
+    ? undefined
+    : { patch, ...(messages === undefined ? {} : { messages }) }
 }
 
 function initialState(cwd: string): ChatViewState {
@@ -977,6 +997,10 @@ class DshSurface implements vscode.Disposable {
   private readonly draftImages: Array<PromptImage & { id: string }> = []
   private ready = false
   private pendingPrompt: string | undefined
+  private pendingState: ChatViewState | undefined
+  private postedState: ChatViewState | undefined
+  private stateTimer: NodeJS.Timeout | undefined
+  private statePosts: Promise<void> = Promise.resolve()
 
   constructor(
     private readonly webview: vscode.Webview,
@@ -989,7 +1013,7 @@ class DshSurface implements vscode.Disposable {
     webview.options = { enableScripts: true, localResourceRoots: [mediaRoot] }
     webview.html = chatHtml(webview, webview.asWebviewUri(vscode.Uri.joinPath(mediaRoot, 'deepseek.svg')))
     this.disposables = [
-      controller.onDidChangeState(state => { void webview.postMessage({ type: 'state', state }) }),
+      controller.onDidChangeState(state => { this.queueState(state) }),
       editorContext.onDidChange(state => { void webview.postMessage({ type: 'ide-context', state }) }),
       webview.onDidReceiveMessage(message => { this.acceptMessage(message) }),
     ]
@@ -1008,7 +1032,51 @@ class DshSurface implements vscode.Disposable {
   }
 
   dispose(): void {
+    if (this.stateTimer !== undefined) clearTimeout(this.stateTimer)
     for (const disposable of this.disposables) disposable.dispose()
+  }
+
+  private queueState(state: ChatViewState): void {
+    this.pendingState = state
+    if (!this.ready || this.stateTimer !== undefined) return
+    this.stateTimer = setTimeout(() => {
+      this.stateTimer = undefined
+      const pending = this.pendingState
+      this.pendingState = undefined
+      if (pending === undefined) return
+      this.statePosts = this.statePosts
+        .then(() => this.postStateUpdate(pending))
+        .catch(error => {
+          this.output.appendLine(`[webview] Could not publish state: ${error instanceof Error ? error.message : String(error)}`)
+        })
+    }, 16)
+  }
+
+  private async postFullState(state: ChatViewState): Promise<void> {
+    await this.webview.postMessage({ type: 'state', state })
+    this.postedState = state
+  }
+
+  private async postStateUpdate(state: ChatViewState): Promise<void> {
+    const previous = this.postedState
+    if (previous === undefined || previous.sessionId !== state.sessionId) {
+      await this.postFullState(state)
+      return
+    }
+    const update = stateUpdate(previous, state)
+    if (update !== undefined) await this.webview.postMessage({ type: 'state-update', update })
+    this.postedState = state
+  }
+
+  private async resyncState(): Promise<void> {
+    const snapshot = this.controller.state
+    this.pendingState = undefined
+    if (this.stateTimer !== undefined) {
+      clearTimeout(this.stateTimer)
+      this.stateTimer = undefined
+    }
+    this.statePosts = this.statePosts.then(() => this.postFullState(snapshot))
+    await this.statePosts
   }
 
   private async chooseImages(): Promise<void> {
@@ -1090,7 +1158,7 @@ class DshSurface implements vscode.Disposable {
           return
         case 'ready':
           this.ready = true
-          await this.webview.postMessage({ type: 'state', state: this.controller.state })
+          await this.resyncState()
           await this.webview.postMessage({ type: 'ide-context', state: this.editorContext.viewState() })
           if (this.pendingPrompt !== undefined) {
             await this.webview.postMessage({ type: 'set-prompt', text: this.pendingPrompt })
@@ -1140,7 +1208,7 @@ class DshSurface implements vscode.Disposable {
                 'Enable Full Access',
               )
               if (confirmed !== 'Enable Full Access') {
-                await this.webview.postMessage({ type: 'state', state: this.controller.state })
+                await this.resyncState()
                 return
               }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1189,15 +1189,21 @@ class DshSurface implements vscode.Disposable {
           return
         case 'load-history': await this.controller.loadOlderHistory(); return
         case 'load-tool-output':
-          if (typeof value.messageId === 'string') {
-            const message = this.controller.state.messages.find(candidate => candidate.id === value.messageId && candidate.role === 'tool')
-            if (message !== undefined) {
-              await this.webview.postMessage({
-                type: 'tool-output',
-                sessionId: this.controller.state.sessionId,
-                message,
-              })
-            }
+          if (typeof value.messageId === 'string' && typeof value.requestId === 'number') {
+            const sessionId = this.controller.state.sessionId
+            const requestedSessionId = typeof value.sessionId === 'string' ? value.sessionId : ''
+            const message = requestedSessionId === sessionId
+              ? this.controller.state.messages.find(candidate => candidate.id === value.messageId && candidate.role === 'tool')
+              : undefined
+            await this.webview.postMessage({
+              type: 'tool-output',
+              sessionId,
+              messageId: value.messageId,
+              requestId: value.requestId,
+              ...(message === undefined
+                ? { error: requestedSessionId === sessionId ? 'Tool output is no longer available.' : 'The conversation changed before this output loaded.' }
+                : { message }),
+            })
           }
           return
         case 'send':

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import { jobsSnapshotOf, type JobItem } from './jobs.js'
 import { queueSnapshotOf, type QueueItemState } from './queue.js'
 import { DshRuntime, type RuntimeOwnership, type RuntimeState } from './runtime.js'
 import { toolWriteIntents } from './tool-write-guard.js'
+import { pageToolOutput } from './tool-output-page.js'
 import { chatHtml } from './webview.js'
 import { DshPluginManager } from './plugin-manager.js'
 import type { PluginInventorySnapshot } from './plugin-profile.js'
@@ -1202,7 +1203,7 @@ class DshSurface implements vscode.Disposable {
               requestId: value.requestId,
               ...(message === undefined
                 ? { error: requestedSessionId === sessionId ? 'Tool output is no longer available.' : 'The conversation changed before this output loaded.' }
-                : { message }),
+                : { page: pageToolOutput(message, typeof value.cursor === 'string' ? value.cursor : undefined) }),
             })
           }
           return

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,12 @@ import type { SettingsDescription, SettingsMutation, SettingsNamespace } from '.
 import { earliestHistorySequence, mergeHistoryEntries, unseenHistoryEntries } from './history.js'
 import { routeSlashInput, type SlashRoute } from './slash-routing.js'
 import { unavailableUsageMeterState, usageMeterStateOf, type UsageMeterState } from './usage-meter.js'
-import { diffConversationMessages, type ConversationMessagesPatch } from './chat-state-patch.js'
+import {
+  diffConversationMessages,
+  messageForWebview,
+  messagesPatchForWebview,
+  type ConversationMessagesPatch,
+} from './chat-state-patch.js'
 
 let activeRuntime: DshRuntime | undefined
 
@@ -152,6 +157,17 @@ function stateUpdate(previous: ChatViewState, next: ChatViewState): ChatViewStat
   return Object.keys(patchRecord).length === 0 && messages === undefined
     ? undefined
     : { patch, ...(messages === undefined ? {} : { messages }) }
+}
+
+function stateForWebview(state: ChatViewState): ChatViewState {
+  return { ...state, messages: state.messages.map(messageForWebview) }
+}
+
+function stateUpdateForWebview(update: ChatViewStateUpdate): ChatViewStateUpdate {
+  return {
+    patch: update.patch,
+    ...(update.messages === undefined ? {} : { messages: messagesPatchForWebview(update.messages) }),
+  }
 }
 
 function initialState(cwd: string): ChatViewState {
@@ -1053,7 +1069,7 @@ class DshSurface implements vscode.Disposable {
   }
 
   private async postFullState(state: ChatViewState): Promise<void> {
-    await this.webview.postMessage({ type: 'state', state })
+    await this.webview.postMessage({ type: 'state', state: stateForWebview(state) })
     this.postedState = state
   }
 
@@ -1064,7 +1080,7 @@ class DshSurface implements vscode.Disposable {
       return
     }
     const update = stateUpdate(previous, state)
-    if (update !== undefined) await this.webview.postMessage({ type: 'state-update', update })
+    if (update !== undefined) await this.webview.postMessage({ type: 'state-update', update: stateUpdateForWebview(update) })
     this.postedState = state
   }
 
@@ -1172,6 +1188,18 @@ class DshSurface implements vscode.Disposable {
           if (typeof value.sessionId === 'string') await this.controller.selectSession(value.sessionId)
           return
         case 'load-history': await this.controller.loadOlderHistory(); return
+        case 'load-tool-output':
+          if (typeof value.messageId === 'string') {
+            const message = this.controller.state.messages.find(candidate => candidate.id === value.messageId && candidate.role === 'tool')
+            if (message !== undefined) {
+              await this.webview.postMessage({
+                type: 'tool-output',
+                sessionId: this.controller.state.sessionId,
+                message,
+              })
+            }
+          }
+          return
         case 'send':
           if (typeof value.text === 'string') {
             if (value.text.trim() === '/permission danger-full-access') {

--- a/src/tool-output-page.ts
+++ b/src/tool-output-page.ts
@@ -109,7 +109,11 @@ function diffPage(message: ConversationMessage, view: View, cursor: Cursor): Too
   const part = diffs[index]
   if (part === undefined) return { message: { ...baseMessage(message), resultView: { card: 'diff', diffs: [] } } }
   const end = Math.min(part.text.length, cursor.offset + TOOL_OUTPUT_CHAR_LIMIT)
-  const diff = { path: part.path, [part.field]: part.text.slice(cursor.offset, end) }
+  const diff = {
+    path: part.path,
+    [part.field]: part.text.slice(cursor.offset, end),
+    ...(cursor.section === 'diff' && cursor.index === index && cursor.offset > 0 ? { continuation: true } : {}),
+  }
   const next = end < part.text.length
     ? nextCursor('diff', index, end)
     : index + 1 < diffs.length ? nextCursor('diff', index + 1) : undefined

--- a/src/tool-output-page.ts
+++ b/src/tool-output-page.ts
@@ -1,0 +1,261 @@
+import type { ConversationMessage } from './conversation.js'
+
+export const TOOL_OUTPUT_CHAR_LIMIT = 20_000
+export const TOOL_OUTPUT_ITEM_LIMIT = 100
+
+export interface ToolOutputPage {
+  message: ConversationMessage
+  nextCursor?: string
+}
+
+interface Cursor {
+  section: string
+  group: number
+  index: number
+  offset: number
+}
+
+type View = Record<string, unknown>
+
+function record(value: unknown): View | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as View : undefined
+}
+
+function cursorOf(value: string | undefined): Cursor {
+  if (value === undefined) return { section: '', group: 0, index: 0, offset: 0 }
+  try {
+    const parsed = JSON.parse(value) as Partial<Cursor>
+    return {
+      section: typeof parsed.section === 'string' ? parsed.section : '',
+      group: Number.isSafeInteger(parsed.group) && Number(parsed.group) >= 0 ? Number(parsed.group) : 0,
+      index: Number.isSafeInteger(parsed.index) && Number(parsed.index) >= 0 ? Number(parsed.index) : 0,
+      offset: Number.isSafeInteger(parsed.offset) && Number(parsed.offset) >= 0 ? Number(parsed.offset) : 0,
+    }
+  } catch {
+    return { section: '', group: 0, index: 0, offset: 0 }
+  }
+}
+
+function nextCursor(section: string, index: number, offset = 0, group = 0): string {
+  return JSON.stringify({ section, group, index, offset })
+}
+
+function textPage(value: string, section: string, cursor: Cursor): { value: string; nextCursor?: string } {
+  const offset = cursor.section === section ? cursor.offset : 0
+  const end = Math.min(value.length, offset + TOOL_OUTPUT_CHAR_LIMIT)
+  return {
+    value: value.slice(offset, end),
+    ...(end < value.length ? { nextCursor: nextCursor(section, 0, end) } : {}),
+  }
+}
+
+function contentText(content: unknown): string {
+  if (!Array.isArray(content)) return ''
+  return content.map((part) => {
+    const item = record(part)
+    if (item === undefined) return ''
+    if (typeof item.text === 'string') return item.text
+    if (typeof item.content === 'string') return item.content
+    return contentText(item.content)
+  }).filter(Boolean).join('\n')
+}
+
+function printable(value: unknown): string {
+  if (typeof value === 'string') return value
+  try { return JSON.stringify(value, null, 2) ?? '' } catch { return String(value) }
+}
+
+function baseMessage(message: ConversationMessage): ConversationMessage {
+  return {
+    id: message.id,
+    role: 'tool',
+    text: message.text,
+    ...(message.detail === undefined ? {} : { detail: message.detail }),
+    ...(message.failed === undefined ? {} : { failed: message.failed }),
+  }
+}
+
+function terminalPage(message: ConversationMessage, call: View | undefined, result: View | undefined, cursor: Cursor): ToolOutputPage {
+  const output = typeof result?.output === 'string'
+    ? result.output
+    : message.rawResult ?? (typeof call?.title === 'string' ? call.title : '')
+  const page = textPage(output, 'output', cursor)
+  return {
+    message: {
+      ...baseMessage(message),
+      ...(call === undefined ? {} : { callView: { card: 'terminal', ...(typeof call.cwd === 'string' ? { cwd: call.cwd } : {}) } }),
+      resultView: {
+        card: 'terminal', output: page.value,
+        ...(typeof result?.exitCode === 'number' ? { exitCode: result.exitCode } : {}),
+        ...(typeof result?.signal === 'string' ? { signal: result.signal } : {}),
+      },
+    },
+    ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+  }
+}
+
+function diffPage(message: ConversationMessage, view: View, cursor: Cursor): ToolOutputPage {
+  const diffs = Array.isArray(view.diffs) ? view.diffs.flatMap((value) => {
+    const diff = record(value)
+    if (diff === undefined) return []
+    const path = typeof diff.path === 'string' ? diff.path : 'File change'
+    return [
+      ...(typeof diff.oldText === 'string' ? [{ path, field: 'oldText', text: diff.oldText }] : []),
+      { path, field: 'newText', text: typeof diff.newText === 'string' ? diff.newText : '' },
+    ]
+  }) : []
+  const index = cursor.section === 'diff' ? Math.min(cursor.index, Math.max(0, diffs.length - 1)) : 0
+  const part = diffs[index]
+  if (part === undefined) return { message: { ...baseMessage(message), resultView: { card: 'diff', diffs: [] } } }
+  const end = Math.min(part.text.length, cursor.offset + TOOL_OUTPUT_CHAR_LIMIT)
+  const diff = { path: part.path, [part.field]: part.text.slice(cursor.offset, end) }
+  const next = end < part.text.length
+    ? nextCursor('diff', index, end)
+    : index + 1 < diffs.length ? nextCursor('diff', index + 1) : undefined
+  return {
+    message: { ...baseMessage(message), resultView: { card: 'diff', diffs: [diff] } },
+    ...(next === undefined ? {} : { nextCursor: next }),
+  }
+}
+
+function readPage(message: ConversationMessage, view: View, cursor: Cursor): ToolOutputPage {
+  const lines = Array.isArray(view.lines) ? view.lines : []
+  if (lines.length === 0) return genericPage(message, view, cursor)
+  let index = cursor.section === 'lines' ? cursor.index : 0
+  let offset = cursor.section === 'lines' ? cursor.offset : 0
+  let budget = TOOL_OUTPUT_CHAR_LIMIT
+  const pageLines: unknown[] = []
+  while (index < lines.length && pageLines.length < TOOL_OUTPUT_ITEM_LIMIT * 2 && budget > 0) {
+    const line = record(lines[index])
+    if (line === undefined) { index += 1; offset = 0; continue }
+    const text = typeof line.text === 'string' ? line.text : ''
+    offset = Math.min(offset, text.length)
+    const length = Math.min(text.length - offset, budget)
+    pageLines.push({ ...line, text: text.slice(offset, offset + length) })
+    budget -= length
+    if (offset + length < text.length) { offset += length; break }
+    index += 1; offset = 0
+  }
+  return {
+    message: {
+      ...baseMessage(message),
+      resultView: {
+        card: 'read', lines: pageLines,
+        ...(typeof view.path === 'string' ? { path: view.path } : {}),
+        ...(typeof view.offset === 'number' ? { offset: view.offset } : {}),
+      },
+    },
+    ...(index < lines.length ? { nextCursor: nextCursor('lines', index, offset) } : {}),
+  }
+}
+
+function searchPage(message: ConversationMessage, view: View, cursor: Cursor): ToolOutputPage {
+  if (view.shape === 'paths') {
+    const paths = Array.isArray(view.paths) ? view.paths : []
+    const index = cursor.section === 'paths' ? cursor.index : 0
+    const end = Math.min(paths.length, index + TOOL_OUTPUT_ITEM_LIMIT)
+    return {
+      message: { ...baseMessage(message), resultView: { card: 'search', shape: 'paths', paths: paths.slice(index, end), ...(view.truncated === true ? { truncated: true, total: view.total } : {}) } },
+      ...(end < paths.length ? { nextCursor: nextCursor('paths', end) } : {}),
+    }
+  }
+  const files = Array.isArray(view.files) ? view.files : []
+  let group = cursor.section === 'matches' ? cursor.group : 0
+  let index = cursor.section === 'matches' ? cursor.index : 0
+  let offset = cursor.section === 'matches' ? cursor.offset : 0
+  let budget = TOOL_OUTPUT_CHAR_LIMIT
+  const pageMatches: Array<{ path: string; match: unknown }> = []
+  while (group < files.length && pageMatches.length < TOOL_OUTPUT_ITEM_LIMIT && budget > 0) {
+    const file = record(files[group])
+    if (file === undefined) { group += 1; index = 0; offset = 0; continue }
+    const matches = Array.isArray(file.matches) ? file.matches : []
+    if (index >= matches.length) { group += 1; index = 0; offset = 0; continue }
+    const match = record(matches[index])
+    if (match === undefined) { index += 1; offset = 0; continue }
+    const line = typeof match.line === 'string' ? match.line : ''
+    offset = Math.min(offset, line.length)
+    const length = Math.min(line.length - offset, budget)
+    pageMatches.push({ path: typeof file.path === 'string' ? file.path : '', match: { ...match, line: line.slice(offset, offset + length) } })
+    budget -= length
+    if (offset + length < line.length) { offset += length; break }
+    index += 1; offset = 0
+  }
+  while (group < files.length) {
+    const file = record(files[group])
+    const matches = file !== undefined && Array.isArray(file.matches) ? file.matches : []
+    if (index < matches.length) break
+    group += 1; index = 0; offset = 0
+  }
+  const grouped = new Map<string, unknown[]>()
+  for (const item of pageMatches) grouped.set(item.path, [...(grouped.get(item.path) ?? []), item.match])
+  return {
+    message: { ...baseMessage(message), resultView: { card: 'search', shape: 'matches', files: [...grouped].map(([path, fileMatches]) => ({ path, matches: fileMatches })), ...(view.truncated === true ? { truncated: true, total: view.total } : {}) } },
+    ...(group < files.length ? { nextCursor: nextCursor('matches', index, offset, group) } : {}),
+  }
+}
+
+function webPage(message: ConversationMessage, view: View, cursor: Cursor): ToolOutputPage {
+  const answer = typeof view.answer === 'string' ? view.answer : ''
+  const sources = Array.isArray(view.sources) ? view.sources : []
+  if (cursor.section !== 'sources' && answer.length > 0) {
+    const page = textPage(answer, 'answer', cursor)
+    const continuation = page.nextCursor ?? (sources.length > 0 ? nextCursor('sources', 0) : undefined)
+    return {
+      message: { ...baseMessage(message), resultView: { card: 'web', answer: page.value } },
+      ...(continuation === undefined ? {} : { nextCursor: continuation }),
+    }
+  }
+  const index = cursor.section === 'sources' ? cursor.index : 0
+  const end = Math.min(sources.length, index + TOOL_OUTPUT_ITEM_LIMIT)
+  return {
+    message: { ...baseMessage(message), resultView: { card: 'web', sources: sources.slice(index, end), ...(typeof view.url === 'string' ? { url: view.url } : {}) } },
+    ...(end < sources.length ? { nextCursor: nextCursor('sources', end) } : {}),
+  }
+}
+
+function genericPage(message: ConversationMessage, view: View | undefined, cursor: Cursor): ToolOutputPage {
+  const presented = contentText(view?.content)
+  const raw = presented || message.rawResult || message.rawInput || (view?.rawInput === undefined ? '' : printable(view.rawInput))
+  const page = textPage(raw, 'raw', cursor)
+  return {
+    message: {
+      ...baseMessage(message),
+      resultView: {
+        card: 'generic',
+        ...(typeof view?.title === 'string' ? { title: view.title } : {}),
+        content: [{ text: page.value }],
+      },
+    },
+    ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
+  }
+}
+
+export function pageToolOutput(message: ConversationMessage, cursorValue?: string): ToolOutputPage {
+  const call = record(message.callView)
+  const result = record(message.resultView)
+  const view = result ?? call
+  const card = typeof view?.card === 'string' ? view.card : 'generic'
+  const cursor = cursorOf(cursorValue)
+  const images = message.images ?? []
+  if (cursor.section === 'images') {
+    const index = Math.min(cursor.index, Math.max(0, images.length - 1))
+    return {
+      message: { ...baseMessage(message), resultView: { card: 'generic', title: 'Image output' }, ...(images[index] === undefined ? {} : { images: [images[index]] }) },
+      ...(index + 1 < images.length ? { nextCursor: nextCursor('images', index + 1) } : {}),
+    }
+  }
+  const page = card === 'terminal'
+    ? terminalPage(message, call, result, cursor)
+    : card === 'diff' && view !== undefined
+      ? diffPage(message, view, cursor)
+      : card === 'read' && view !== undefined
+        ? readPage(message, view, cursor)
+        : card === 'search' && view !== undefined
+          ? searchPage(message, view, cursor)
+          : card === 'web' && view !== undefined
+            ? webPage(message, view, cursor)
+            : genericPage(message, view, cursor)
+  return page.nextCursor !== undefined || images.length === 0
+    ? page
+    : { ...page, nextCursor: nextCursor('images', 0) }
+}

--- a/src/tool-output-page.ts
+++ b/src/tool-output-page.ts
@@ -16,6 +16,7 @@ interface Cursor {
 }
 
 type View = Record<string, unknown>
+const genericTextCache = new WeakMap<ConversationMessage, string>()
 
 function record(value: unknown): View | undefined {
   return typeof value === 'object' && value !== null && !Array.isArray(value) ? value as View : undefined
@@ -68,7 +69,7 @@ function printable(value: unknown): string {
 function baseMessage(message: ConversationMessage): ConversationMessage {
   return {
     id: message.id,
-    role: 'tool',
+    role: message.role,
     text: message.text,
     ...(message.detail === undefined ? {} : { detail: message.detail }),
     ...(message.failed === undefined ? {} : { failed: message.failed }),
@@ -86,8 +87,8 @@ function terminalPage(message: ConversationMessage, call: View | undefined, resu
       ...(call === undefined ? {} : { callView: { card: 'terminal', ...(typeof call.cwd === 'string' ? { cwd: call.cwd } : {}) } }),
       resultView: {
         card: 'terminal', output: page.value,
-        ...(typeof result?.exitCode === 'number' ? { exitCode: result.exitCode } : {}),
-        ...(typeof result?.signal === 'string' ? { signal: result.signal } : {}),
+        ...(page.nextCursor === undefined && typeof result?.exitCode === 'number' ? { exitCode: result.exitCode } : {}),
+        ...(page.nextCursor === undefined && typeof result?.signal === 'string' ? { signal: result.signal } : {}),
       },
     },
     ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
@@ -201,7 +202,7 @@ function webPage(message: ConversationMessage, view: View, cursor: Cursor): Tool
     const page = textPage(answer, 'answer', cursor)
     const continuation = page.nextCursor ?? (sources.length > 0 ? nextCursor('sources', 0) : undefined)
     return {
-      message: { ...baseMessage(message), resultView: { card: 'web', answer: page.value } },
+      message: { ...baseMessage(message), resultView: { card: 'web', answer: page.value, ...(answer.length > TOOL_OUTPUT_CHAR_LIMIT ? { plainText: true } : {}) } },
       ...(continuation === undefined ? {} : { nextCursor: continuation }),
     }
   }
@@ -214,9 +215,24 @@ function webPage(message: ConversationMessage, view: View, cursor: Cursor): Tool
 }
 
 function genericPage(message: ConversationMessage, view: View | undefined, cursor: Cursor): ToolOutputPage {
-  const presented = contentText(view?.content)
+  const call = record(message.callView)
+  const locations = Array.isArray(call?.locations) ? call.locations : []
+  if (cursor.section === 'locations') {
+    const end = Math.min(locations.length, cursor.index + TOOL_OUTPUT_ITEM_LIMIT)
+    return {
+      message: { ...baseMessage(message), callView: { card: 'generic', locations: locations.slice(cursor.index, end) }, resultView: { card: 'generic' } },
+      ...(end < locations.length ? { nextCursor: nextCursor('locations', end) } : {}),
+    }
+  }
+  let presented = genericTextCache.get(message)
+  if (presented === undefined) {
+    presented = contentText(view?.content)
+    genericTextCache.set(message, presented)
+  }
   const raw = presented || message.rawResult || message.rawInput || (view?.rawInput === undefined ? '' : printable(view.rawInput))
+  if (raw === '' && locations.length > 0) return genericPage(message, view, { section: 'locations', group: 0, index: 0, offset: 0 })
   const page = textPage(raw, 'raw', cursor)
+  const continuation = page.nextCursor ?? (locations.length > 0 ? nextCursor('locations', 0) : undefined)
   return {
     message: {
       ...baseMessage(message),
@@ -226,11 +242,23 @@ function genericPage(message: ConversationMessage, view: View | undefined, curso
         content: [{ text: page.value }],
       },
     },
+    ...(continuation === undefined ? {} : { nextCursor: continuation }),
+  }
+}
+
+function assistantPage(message: ConversationMessage, cursor: Cursor): ToolOutputPage {
+  const page = textPage(message.text, 'assistant', cursor)
+  return {
+    message: {
+      ...baseMessage(message),
+      text: page.value,
+      ...(message.text.length > TOOL_OUTPUT_CHAR_LIMIT ? { resultView: { card: 'assistant-page', plainText: true } } : {}),
+    },
     ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
   }
 }
 
-export function pageToolOutput(message: ConversationMessage, cursorValue?: string): ToolOutputPage {
+export function pageConversationMessage(message: ConversationMessage, cursorValue?: string): ToolOutputPage {
   const call = record(message.callView)
   const result = record(message.resultView)
   const view = result ?? call
@@ -240,11 +268,13 @@ export function pageToolOutput(message: ConversationMessage, cursorValue?: strin
   if (cursor.section === 'images') {
     const index = Math.min(cursor.index, Math.max(0, images.length - 1))
     return {
-      message: { ...baseMessage(message), resultView: { card: 'generic', title: 'Image output' }, ...(images[index] === undefined ? {} : { images: [images[index]] }) },
+      message: { ...baseMessage(message), ...(message.role === 'assistant' ? { text: '' } : {}), resultView: { card: 'generic', title: 'Image output' }, ...(images[index] === undefined ? {} : { images: [images[index]] }) },
       ...(index + 1 < images.length ? { nextCursor: nextCursor('images', index + 1) } : {}),
     }
   }
-  const page = card === 'terminal'
+  const page = message.role === 'assistant'
+    ? assistantPage(message, cursor)
+    : card === 'terminal'
     ? terminalPage(message, call, result, cursor)
     : card === 'diff' && view !== undefined
       ? diffPage(message, view, cursor)
@@ -255,7 +285,16 @@ export function pageToolOutput(message: ConversationMessage, cursorValue?: strin
           : card === 'web' && view !== undefined
             ? webPage(message, view, cursor)
             : genericPage(message, view, cursor)
-  return page.nextCursor !== undefined || images.length === 0
-    ? page
-    : { ...page, nextCursor: nextCursor('images', 0) }
+  if (page.nextCursor !== undefined || images.length === 0) return page
+  const pageResult = record(page.message.resultView)
+  const content = Array.isArray(pageResult?.content) ? pageResult.content : []
+  const firstContent = record(content[0])
+  const emptyGenericPage = pageResult?.card === 'generic' && content.length <= 1 && (firstContent?.text ?? '') === ''
+  if (emptyGenericPage) {
+    return pageConversationMessage(message, nextCursor('images', 0))
+  }
+  return { ...page, nextCursor: nextCursor('images', 0) }
 }
+
+/** @deprecated Use pageConversationMessage for tool, command, and assistant bodies. */
+export const pageToolOutput = pageConversationMessage

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -315,7 +315,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let renderedChrome = {};
     const renderedMessages = new Map();
     const expandedToolIds = new Set();
-    const loadingToolIds = new Set();
+    const loadingToolRequests = new Map();
+    const toolOutputErrors = new Map();
+    let toolOutputRequestId = 0;
     const toolOutputChunkSize = 20000;
 
     function node(tag, className, text) {
@@ -656,10 +658,19 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         if (contentInitialized) return;
         contentInitialized = true;
         if (message.deferredBody === true) {
-          item.append(node('div', 'tool-body', 'Loading tool output…'));
-          if (!loadingToolIds.has(message.id)) {
-            loadingToolIds.add(message.id); vscode.postMessage({ type: 'load-tool-output', messageId: message.id });
-          }
+          const body = node('div', 'tool-body'); item.append(body);
+          const load = () => {
+            const requestId = ++toolOutputRequestId;
+            loadingToolRequests.set(message.id, requestId); toolOutputErrors.delete(message.id);
+            body.replaceChildren(node('div', '', 'Loading tool output…'));
+            vscode.postMessage({ type: 'load-tool-output', messageId: message.id, sessionId: state && state.sessionId, requestId });
+          };
+          const error = toolOutputErrors.get(message.id);
+          if (error) {
+            body.append(node('div', 'status error', error));
+            const retry = node('button', 'tool-output-more', 'Retry'); retry.type = 'button'; retry.addEventListener('click', load); body.append(retry);
+          } else if (!loadingToolRequests.has(message.id)) load();
+          else body.append(node('div', '', 'Loading tool output…'));
         } else item.append(renderToolBody(message, callView, resultView));
       };
       if (item.open) initializeContent();
@@ -1237,7 +1248,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function renderConversation(current) {
       if (renderedSessionId !== current.sessionId) {
         renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
-        renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear(); loadingToolIds.clear();
+        renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear(); loadingToolRequests.clear(); toolOutputErrors.clear();
       }
       const statusKey = current.phase + '::' + current.statusText;
       if (statusKey !== renderedStatusKey) {
@@ -1404,9 +1415,15 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (!event.data) return;
       if (event.data.type === 'state') scheduleRender(event.data.state);
       if (event.data.type === 'state-update') applyStateUpdate(event.data.update);
-      if (event.data.type === 'tool-output' && state && event.data.sessionId === state.sessionId && event.data.message) {
-        loadingToolIds.delete(event.data.message.id);
-        scheduleRender({ ...state, messages: applyMessagesPatch(state.messages, { upserts: [event.data.message] }) });
+      if (event.data.type === 'tool-output' && state && event.data.sessionId === state.sessionId && typeof event.data.messageId === 'string') {
+        if (loadingToolRequests.get(event.data.messageId) !== event.data.requestId) return;
+        loadingToolRequests.delete(event.data.messageId);
+        if (typeof event.data.error === 'string') {
+          toolOutputErrors.set(event.data.messageId, event.data.error); renderedMessages.delete(event.data.messageId);
+          scheduleRender({ ...state, messages: [...state.messages] }); return;
+        }
+        toolOutputErrors.delete(event.data.messageId);
+        if (event.data.message) scheduleRender({ ...state, messages: applyMessagesPatch(state.messages, { upserts: [event.data.message] }) });
       }
       if (event.data.type === 'draft-images') { draftImages = event.data.images || []; renderAttachments(); }
       if (event.data.type === 'ide-context') { ideContext = event.data.state || { pinned: [] }; renderIdeContext(); }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -109,6 +109,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     .diff-old { border-left: 2px solid var(--vscode-gitDecoration-deletedResourceForeground); }
     .diff-new { border-left: 2px solid var(--vscode-gitDecoration-addedResourceForeground); }
     .source { display: block; margin: 4px 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+    .source-line { white-space: pre-wrap; overflow-wrap: anywhere; font-family: var(--vscode-editor-font-family); font-size: 11px; }
     .tool-actions { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 2px; }
     .tool-action { min-height: 24px; padding: 2px 7px; border: 1px solid var(--vscode-widget-border); border-radius: 5px; color: var(--vscode-foreground); background: transparent; font-size: 11px; }
     .tool-action:hover { background: var(--vscode-toolbar-hoverBackground); }
@@ -311,6 +312,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let renderedStatusKey = '';
     let renderedHistoryKey = '';
     let renderedTail = {};
+    let renderedChrome = {};
     const renderedMessages = new Map();
     const expandedToolIds = new Set();
     const loadingToolIds = new Set();
@@ -433,6 +435,57 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       return root;
     }
 
+    function createMarkdownStream(text) {
+      const stream = {
+        root: node('div', 'markdown'), text: '', committedOffset: 0, scanOffset: 0,
+        safeBoundary: 0, fenced: false, linePrefix: '', lineHasContent: false, tailNodes: [], marker: document.createComment('stream-end'),
+      };
+      stream.root.append(stream.marker);
+      updateMarkdownStream(stream, text, true);
+      return stream;
+    }
+    function scanMarkdownStream(stream, text) {
+      for (let index = stream.scanOffset; index < text.length; index += 1) {
+        const character = text[index];
+        if (character === '\\n') {
+          if (stream.linePrefix === String.fromCharCode(96).repeat(3)) stream.fenced = !stream.fenced;
+          else if (!stream.lineHasContent && !stream.fenced) stream.safeBoundary = index + 1;
+          stream.linePrefix = ''; stream.lineHasContent = false;
+        } else {
+          if (stream.linePrefix.length < 3) stream.linePrefix += character;
+          if (!/\\s/.test(character)) stream.lineHasContent = true;
+        }
+      }
+      stream.scanOffset = text.length;
+    }
+    function appendMarkdownNodes(parent, text, before) {
+      if (!text) return [];
+      const parsed = renderMarkdown(text); const children = [...parsed.childNodes];
+      for (const child of children) parent.insertBefore(child, before || null);
+      return children;
+    }
+    function updateMarkdownStream(stream, text, streaming) {
+      const value = String(text || '');
+      if (!value.startsWith(stream.text)) return false;
+      scanMarkdownStream(stream, value);
+      for (const child of stream.tailNodes) child.remove();
+      stream.tailNodes = [];
+      const boundary = streaming ? stream.safeBoundary : value.length;
+      if (boundary > stream.committedOffset) {
+        appendMarkdownNodes(stream.root, value.slice(stream.committedOffset, boundary), stream.marker);
+        stream.committedOffset = boundary;
+      }
+      if (streaming && boundary < value.length) {
+        const tail = value.slice(boundary);
+        stream.tailNodes = tail.length > toolOutputChunkSize
+          ? [node('p', 'streaming-plain', tail)]
+          : appendMarkdownNodes(stream.root, tail, stream.marker);
+        if (stream.tailNodes.length === 1 && !stream.tailNodes[0].isConnected) stream.root.insertBefore(stream.tailNodes[0], stream.marker);
+      }
+      stream.text = value;
+      return true;
+    }
+
     function toolTitle(message, callView, resultView) {
       return string(resultView && resultView.title) || string(callView && callView.title) || message.text || 'Tool';
     }
@@ -466,6 +519,54 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       });
       parent.append(more);
     }
+    function appendPrefixedPre(parent, text, prefix, className) {
+      const value = String(text || '');
+      if (!value) return;
+      let visible = Math.min(value.length, toolOutputChunkSize);
+      const format = () => prefix + value.slice(0, visible).replace(/\\n/g, '\\n' + prefix);
+      const pre = node('pre', className || '', format()); parent.append(pre);
+      if (visible >= value.length) return;
+      const more = node('button', 'tool-output-more'); more.type = 'button';
+      const updateLabel = () => { more.textContent = 'Show more · ' + String(visible) + ' / ' + String(value.length) + ' characters'; };
+      updateLabel();
+      more.addEventListener('click', () => {
+        visible = Math.min(value.length, visible + toolOutputChunkSize); pre.textContent = format();
+        if (visible >= value.length) more.remove(); else updateLabel();
+      });
+      parent.append(more);
+    }
+    function appendMarkdownPage(parent, text) {
+      const value = String(text || '');
+      if (!value) return;
+      let visible = Math.min(value.length, toolOutputChunkSize);
+      const content = node('div'); const more = node('button', 'tool-output-more'); more.type = 'button';
+      const renderPage = () => {
+        content.replaceChildren(renderMarkdown(value.slice(0, visible)));
+        more.textContent = 'Show more · ' + String(visible) + ' / ' + String(value.length) + ' characters';
+      };
+      renderPage(); parent.append(content);
+      if (visible < value.length) {
+        more.addEventListener('click', () => {
+          visible = Math.min(value.length, visible + toolOutputChunkSize); renderPage();
+          if (visible >= value.length) more.remove();
+        });
+        parent.append(more);
+      }
+    }
+    function appendPagedItems(parent, values, appendItem, pageSize) {
+      if (!values.length) return;
+      const container = node('div'); const more = node('button', 'tool-output-more'); more.type = 'button';
+      let visible = 0; const size = pageSize || 100;
+      const reveal = () => {
+        const end = Math.min(values.length, visible + size);
+        for (let index = visible; index < end; index += 1) appendItem(container, values[index]);
+        visible = end;
+        more.textContent = 'Show more · ' + String(visible) + ' / ' + String(values.length) + ' results';
+        if (visible >= values.length) more.remove();
+      };
+      parent.append(container); reveal();
+      if (visible < values.length) { more.addEventListener('click', reveal); parent.append(more); }
+    }
     function renderToolBody(message, callView, resultView) {
       const body = node('div', 'tool-body');
       const view = resultView || callView;
@@ -484,8 +585,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
           const pathRow = node('div', 'diff-path');
           pathRow.append(filePath === 'File change' ? document.createTextNode(filePath) : fileButton(filePath, undefined, filePath));
           body.append(pathRow);
-          if (typeof diff.oldText === 'string') appendPre(body, '- ' + diff.oldText.replace(/\\n/g, '\\n- '), 'diff-old');
-          appendPre(body, '+ ' + string(diff.newText).replace(/\\n/g, '\\n+ '), 'diff-new');
+          if (typeof diff.oldText === 'string') appendPrefixedPre(body, diff.oldText, '- ', 'diff-old');
+          appendPrefixedPre(body, string(diff.newText), '+ ', 'diff-new');
         }
         for (const filePath of paths) {
           const actions = node('div', 'tool-actions');
@@ -500,24 +601,32 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       } else if (card === 'read') {
         const filePath = string(view.path, 'File'); const title = node('div', 'result-title');
         title.append(filePath === 'File' ? document.createTextNode(filePath) : fileButton(filePath, Number(view.offset) || undefined, filePath)); body.append(title);
-        const lines = array(view.lines).map(value => { const line = record(value); return line ? String(line.number).padStart(4, ' ') + '  ' + string(line.text) : ''; }).filter(Boolean);
-        appendPre(body, lines.join('\\n') || message.rawResult);
+        const lines = array(view.lines);
+        if (lines.length) appendPagedItems(body, lines, (container, value) => {
+          const line = record(value); if (line) container.append(node('div', 'source-line', String(line.number).padStart(4, ' ') + '  ' + string(line.text)));
+        }, 200);
+        else appendPre(body, message.rawResult);
       } else if (card === 'search') {
-        if (view.shape === 'paths') for (const pathValue of array(view.paths)) {
-          const filePath = string(pathValue); const row = node('div', 'source'); if (filePath) row.append(fileButton(filePath, undefined, filePath)); body.append(row);
-        }
-        if (view.shape === 'matches') for (const fileValue of array(view.files)) {
-          const file = record(fileValue); if (!file) continue;
-          const filePath = string(file.path); const title = node('div', 'result-title'); if (filePath) title.append(fileButton(filePath, undefined, filePath)); body.append(title);
-          for (const matchValue of array(file.matches)) {
-            const match = record(matchValue); if (!match) continue; const line = Number(match.lineNumber) || undefined; const row = node('div', 'source');
-            if (filePath) row.append(fileButton(filePath, line, String(match.lineNumber) + ': ' + string(match.line))); body.append(row);
+        if (view.shape === 'paths') appendPagedItems(body, array(view.paths), (container, pathValue) => {
+          const filePath = string(pathValue); const row = node('div', 'source'); if (filePath) row.append(fileButton(filePath, undefined, filePath)); container.append(row);
+        }, 100);
+        if (view.shape === 'matches') {
+          const matches = [];
+          for (const fileValue of array(view.files)) {
+            const file = record(fileValue); if (!file) continue; const filePath = string(file.path);
+            matches.push({ kind: 'file', path: filePath });
+            for (const matchValue of array(file.matches)) matches.push({ kind: 'match', path: filePath, value: matchValue });
           }
+          appendPagedItems(body, matches, (container, entry) => {
+            if (entry.kind === 'file') { const title = node('div', 'result-title'); if (entry.path) title.append(fileButton(entry.path, undefined, entry.path)); container.append(title); return; }
+            const match = record(entry.value); if (!match) return; const line = Number(match.lineNumber) || undefined; const row = node('div', 'source');
+            if (entry.path) row.append(fileButton(entry.path, line, String(match.lineNumber) + ': ' + string(match.line))); container.append(row);
+          }, 100);
         }
         if (view.truncated === true) body.append(node('div', '', 'Showing a limited result set (' + String(view.total || '') + ' total).'));
       } else if (card === 'web') {
-        if (typeof view.answer === 'string') body.append(renderMarkdown(view.answer));
-        for (const sourceValue of array(view.sources)) { const source = record(sourceValue); if (source && typeof source.url === 'string') body.append(link(source.url, string(source.title) || source.url)); }
+        if (typeof view.answer === 'string') appendMarkdownPage(body, view.answer);
+        appendPagedItems(body, array(view.sources), (container, sourceValue) => { const source = record(sourceValue); if (source && typeof source.url === 'string') container.append(link(source.url, string(source.title) || source.url)); }, 50);
         if (typeof view.url === 'string') body.append(link(view.url, view.url));
       } else {
         const presented = contentText(view && view.content);
@@ -567,7 +676,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       head.append(node('span', 'command-name', message.text));
       head.append(node('span', 'tool-detail', message.detail || ''));
       item.append(head);
-      if (message.rawResult) item.append(node('div', 'command-result', message.rawResult));
+      if (message.rawResult) { const result = node('div', 'command-result'); appendPre(result, message.rawResult); item.append(result); }
       return item;
     }
     function renderChangedFiles(groups) {
@@ -598,26 +707,32 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       bubble.append(body); return bubble;
     }
     function renderMessage(message) {
-      if (message.role === 'tool') return renderTool(message);
-      if (message.role === 'command') return renderCommand(message);
-      if (message.role === 'notice') return node('div', 'status' + (message.failed ? ' error' : ''), message.text);
+      if (message.role === 'tool') return { message, node: renderTool(message) };
+      if (message.role === 'command') return { message, node: renderCommand(message) };
+      if (message.role === 'notice') return { message, node: node('div', 'status' + (message.failed ? ' error' : ''), message.text) };
       const item = node('article', 'message ' + message.role);
       const head = node('div', 'message-head');
       head.append(node('span', 'avatar' + (message.role === 'assistant' ? ' deepseek-mark' : ''), message.role === 'user' ? 'Y' : ''));
       head.append(node('span', '', message.role === 'user' ? 'You' : 'DeepSeek'));
-      const body = message.role === 'assistant' ? renderMarkdown(message.text) : node('div', '', message.text);
+      const markdown = message.role === 'assistant' && message.streaming === true ? createMarkdownStream(message.text) : undefined;
+      const body = message.role === 'assistant' ? (markdown ? markdown.root : renderMarkdown(message.text)) : node('div', '', message.text);
       body.classList.add('message-body');
       if (message.streaming) body.classList.add('streaming');
       appendImages(body, message.images);
-      item.append(head, body); return item;
+      item.append(head, body); return { message, node: item, ...(markdown ? { markdown } : {}) };
     }
     function messageNode(message) {
       const rendered = renderedMessages.get(message.id);
       if (rendered && rendered.message === message) return rendered.node;
+      if (rendered && rendered.markdown && message.role === 'assistant' && message.images === rendered.message.images && updateMarkdownStream(rendered.markdown, message.text, message.streaming === true)) {
+        rendered.message = message;
+        rendered.markdown.root.classList.toggle('streaming', message.streaming === true);
+        return rendered.node;
+      }
       const next = renderMessage(message);
-      if (rendered && rendered.node.isConnected) rendered.node.replaceWith(next);
-      renderedMessages.set(message.id, { message, node: next });
-      return next;
+      if (rendered && rendered.node.isConnected) rendered.node.replaceWith(next.node);
+      renderedMessages.set(message.id, next);
+      return next.node;
     }
     function reconcileMessages(messages, current) {
       if (!messages.length) {
@@ -1132,6 +1247,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       }
       if (current.phase !== 'ready') {
         elements.conversationHistory.replaceChildren(); elements.messages.replaceChildren(); elements.conversationTail.replaceChildren();
+        renderedHistoryKey = ''; renderedTail = {};
         return;
       }
 
@@ -1157,23 +1273,36 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function render(current) {
       const nearBottom = elements.scroll.scrollHeight - elements.scroll.scrollTop - elements.scroll.clientHeight < 80;
       const preservingHistory = historyAnchor && historyAnchor.sessionId === current.sessionId;
-      state = current; elements.workspace.textContent = current.workspaceName || 'Workspace'; elements.project.title = current.cwd ? 'DeepSeek project: ' + current.cwd : 'Choose DeepSeek project';
-      elements.sessions.replaceChildren();
-      for (const session of current.sessions || []) { const option = new Option(session.title, session.id, false, session.id === current.sessionId); elements.sessions.append(option); }
-      if (!elements.sessions.childElementCount) elements.sessions.append(new Option('New conversation', ''));
-      elements.models.replaceChildren();
-      for (const model of current.models || []) { const option = new Option(model.label, JSON.stringify({ provider: model.provider, model: model.model }), false, model.selected === true); elements.models.append(option); }
-      if (!elements.models.childElementCount) elements.models.append(new Option('Default model', ''));
-      renderEfforts((current.models || []).find(model => model.selected) || (current.models || [])[0]);
-      renderPolicyState(current);
-      renderUsage(current);
-      renderJobs();
+      state = current;
+      if (renderedChrome.workspaceName !== current.workspaceName || renderedChrome.cwd !== current.cwd) {
+        elements.workspace.textContent = current.workspaceName || 'Workspace'; elements.project.title = current.cwd ? 'DeepSeek project: ' + current.cwd : 'Choose DeepSeek project';
+      }
+      if (renderedChrome.sessions !== current.sessions) {
+        elements.sessions.replaceChildren();
+        for (const session of current.sessions || []) { const option = new Option(session.title, session.id, false, session.id === current.sessionId); elements.sessions.append(option); }
+        if (!elements.sessions.childElementCount) elements.sessions.append(new Option('New conversation', ''));
+      } else if (elements.sessions.value !== current.sessionId) elements.sessions.value = current.sessionId;
+      if (renderedChrome.models !== current.models) {
+        elements.models.replaceChildren();
+        for (const model of current.models || []) { const option = new Option(model.label, JSON.stringify({ provider: model.provider, model: model.model }), false, model.selected === true); elements.models.append(option); }
+        if (!elements.models.childElementCount) elements.models.append(new Option('Default model', ''));
+        renderEfforts((current.models || []).find(model => model.selected) || (current.models || [])[0]);
+      }
+      const policyChanged = renderedChrome.agentPreset !== current.agentPreset || renderedChrome.permissions !== current.permissions || renderedChrome.plan !== current.plan || renderedChrome.running !== current.running || renderedChrome.phase !== current.phase;
+      if (policyChanged) renderPolicyState(current);
+      if (renderedChrome.usage !== current.usage) renderUsage(current);
+      if (renderedChrome.jobs !== current.jobs) renderJobs();
       renderConversation(current);
       const enabled = current.phase === 'ready' && current.routable !== false && Boolean(current.sessionId);
       elements.prompt.disabled = !enabled; elements.attach.disabled = !enabled; elements.project.disabled = current.running === true; elements.newSession.disabled = current.phase !== 'ready'; elements.sessions.disabled = current.phase !== 'ready';
       elements.models.disabled = !enabled || !(current.models || []).length; elements.efforts.disabled = !enabled || !elements.efforts.options.length || elements.efforts.value === '';
       elements.cancel.classList.toggle('hidden', current.running !== true); elements.send.title = current.running ? 'Queue message (Enter) · Steer now (Cmd/Ctrl+Enter)' : 'Send (Enter)'; updateSend(); renderQueue();
-      renderCommandMenu();
+      if (renderedChrome.commands !== current.commands || renderedChrome.skills !== current.skills || renderedChrome.permissions !== current.permissions) renderCommandMenu();
+      renderedChrome = {
+        workspaceName: current.workspaceName, cwd: current.cwd, sessions: current.sessions, models: current.models,
+        agentPreset: current.agentPreset, permissions: current.permissions, plan: current.plan, running: current.running,
+        phase: current.phase, usage: current.usage, jobs: current.jobs, commands: current.commands, skills: current.skills,
+      };
       if (preservingHistory && current.loadingHistory !== true) {
         const anchor = historyAnchor; historyAnchor = undefined;
         requestAnimationFrame(() => { elements.scroll.scrollTop = anchor.top + elements.scroll.scrollHeight - anchor.height; });
@@ -1196,6 +1325,11 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         const index = indexes.get(message.id);
         if (index === undefined) { indexes.set(message.id, messages.length); messages.push(message); }
         else messages[index] = message;
+      }
+      for (const append of array(patch && patch.appends)) {
+        const index = indexes.get(append.id); const message = index === undefined ? undefined : messages[index];
+        if (!message || message.role !== 'assistant') continue;
+        messages[index] = { ...message, text: message.text + string(append.text), streaming: append.streaming === true };
       }
       return messages;
     }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -76,6 +76,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     .pending-steering .message-body::after { content: 'Steering…'; display: block; margin-top: 3px; color: var(--vscode-descriptionForeground); font-size: 10px; }
     .markdown > :first-child { margin-top: 0; }
     .markdown > :last-child { margin-bottom: 0; }
+    .streaming-plain { white-space: pre-wrap; overflow-wrap: anywhere; }
     .markdown p { margin: 0 0 9px; }
     .markdown h1, .markdown h2, .markdown h3 { margin: 14px 0 7px; line-height: 1.3; }
     .markdown h1 { font-size: 17px; } .markdown h2 { font-size: 15px; } .markdown h3 { font-size: 13px; }
@@ -318,6 +319,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     const loadingToolRequests = new Map();
     const toolOutputErrors = new Map();
     const toolOutputPages = new Map();
+    const deferredOutputViews = new Map();
+    const pendingMessageAppends = new Map();
     let toolOutputRequestId = 0;
     const toolOutputChunkSize = 20000;
 
@@ -441,10 +444,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function createMarkdownStream(text) {
       const stream = {
         root: node('div', 'markdown'), text: '', committedOffset: 0, scanOffset: 0,
-        safeBoundary: 0, fenced: false, linePrefix: '', lineHasContent: false, tailNodes: [], marker: document.createComment('stream-end'),
+        safeBoundary: 0, fenced: false, linePrefix: '', lineHasContent: false, tailNode: undefined, marker: document.createComment('stream-end'),
       };
       stream.root.append(stream.marker);
-      updateMarkdownStream(stream, text, true);
+      appendMarkdownStream(stream, String(text || ''), true);
       return stream;
     }
     function scanMarkdownStream(stream, text) {
@@ -463,30 +466,32 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     }
     function appendMarkdownNodes(parent, text, before) {
       if (!text) return [];
-      const parsed = renderMarkdown(text); const children = [...parsed.childNodes];
+      const parsed = text.length > toolOutputChunkSize ? node('div', 'streaming-plain', text) : renderMarkdown(text);
+      const children = parsed.classList && parsed.classList.contains('streaming-plain') ? [parsed] : [...parsed.childNodes];
       for (const child of children) parent.insertBefore(child, before || null);
       return children;
     }
-    function updateMarkdownStream(stream, text, streaming) {
-      const value = String(text || '');
-      if (!value.startsWith(stream.text)) return false;
-      scanMarkdownStream(stream, value);
-      for (const child of stream.tailNodes) child.remove();
-      stream.tailNodes = [];
-      const boundary = streaming ? stream.safeBoundary : value.length;
+    function appendMarkdownStream(stream, delta, streaming) {
+      const previousBoundary = stream.safeBoundary;
+      stream.text += String(delta || '');
+      scanMarkdownStream(stream, stream.text);
+      const boundary = streaming ? stream.safeBoundary : stream.text.length;
       if (boundary > stream.committedOffset) {
-        appendMarkdownNodes(stream.root, value.slice(stream.committedOffset, boundary), stream.marker);
+        if (stream.tailNode) stream.tailNode.remove();
+        stream.tailNode = undefined;
+        appendMarkdownNodes(stream.root, stream.text.slice(stream.committedOffset, boundary), stream.marker);
         stream.committedOffset = boundary;
       }
-      if (streaming && boundary < value.length) {
-        const tail = value.slice(boundary);
-        stream.tailNodes = tail.length > toolOutputChunkSize
-          ? [node('p', 'streaming-plain', tail)]
-          : appendMarkdownNodes(stream.root, tail, stream.marker);
-        if (stream.tailNodes.length === 1 && !stream.tailNodes[0].isConnected) stream.root.insertBefore(stream.tailNodes[0], stream.marker);
+      if (streaming && boundary < stream.text.length) {
+        if (stream.tailNode && boundary === previousBoundary && stream.tailNode.firstChild) stream.tailNode.firstChild.appendData(String(delta || ''));
+        else {
+          if (stream.tailNode) stream.tailNode.remove();
+          stream.tailNode = node('div', 'streaming-plain'); stream.tailNode.append(document.createTextNode(stream.text.slice(boundary)));
+          stream.root.insertBefore(stream.tailNode, stream.marker);
+        }
+      } else if (stream.tailNode) {
+        stream.tailNode.remove(); stream.tailNode = undefined;
       }
-      stream.text = value;
-      return true;
     }
 
     function toolTitle(message, callView, resultView) {
@@ -510,65 +515,23 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     }
     function appendPre(parent, text, className) {
       if (!text) return;
-      const value = String(text); let visible = Math.min(value.length, toolOutputChunkSize);
-      const pre = node('pre', className || '', value.slice(0, visible)); parent.append(pre);
-      if (visible >= value.length) return;
-      const more = node('button', 'tool-output-more'); more.type = 'button';
-      const updateLabel = () => { more.textContent = 'Show more · ' + String(visible) + ' / ' + String(value.length) + ' characters'; };
-      updateLabel();
-      more.addEventListener('click', () => {
-        visible = Math.min(value.length, visible + toolOutputChunkSize); pre.textContent = value.slice(0, visible);
-        if (visible >= value.length) more.remove(); else updateLabel();
-      });
-      parent.append(more);
+      parent.append(node('pre', className || '', String(text)));
     }
     function appendPrefixedPre(parent, text, prefix, className) {
       const value = String(text || '');
       if (!value) return;
-      let visible = Math.min(value.length, toolOutputChunkSize);
-      const format = () => prefix + value.slice(0, visible).replace(/\\n/g, '\\n' + prefix);
-      const pre = node('pre', className || '', format()); parent.append(pre);
-      if (visible >= value.length) return;
-      const more = node('button', 'tool-output-more'); more.type = 'button';
-      const updateLabel = () => { more.textContent = 'Show more · ' + String(visible) + ' / ' + String(value.length) + ' characters'; };
-      updateLabel();
-      more.addEventListener('click', () => {
-        visible = Math.min(value.length, visible + toolOutputChunkSize); pre.textContent = format();
-        if (visible >= value.length) more.remove(); else updateLabel();
-      });
-      parent.append(more);
+      parent.append(node('pre', className || '', prefix + value.replace(/\\n/g, '\\n' + prefix)));
     }
     function appendMarkdownPage(parent, text) {
       const value = String(text || '');
       if (!value) return;
-      let visible = Math.min(value.length, toolOutputChunkSize);
-      const content = node('div'); const more = node('button', 'tool-output-more'); more.type = 'button';
-      const renderPage = () => {
-        content.replaceChildren(renderMarkdown(value.slice(0, visible)));
-        more.textContent = 'Show more · ' + String(visible) + ' / ' + String(value.length) + ' characters';
-      };
-      renderPage(); parent.append(content);
-      if (visible < value.length) {
-        more.addEventListener('click', () => {
-          visible = Math.min(value.length, visible + toolOutputChunkSize); renderPage();
-          if (visible >= value.length) more.remove();
-        });
-        parent.append(more);
-      }
+      parent.append(renderMarkdown(value));
     }
-    function appendPagedItems(parent, values, appendItem, pageSize) {
+    function appendItems(parent, values, appendItem) {
       if (!values.length) return;
-      const container = node('div'); const more = node('button', 'tool-output-more'); more.type = 'button';
-      let visible = 0; const size = pageSize || 100;
-      const reveal = () => {
-        const end = Math.min(values.length, visible + size);
-        for (let index = visible; index < end; index += 1) appendItem(container, values[index]);
-        visible = end;
-        more.textContent = 'Show more · ' + String(visible) + ' / ' + String(values.length) + ' results';
-        if (visible >= values.length) more.remove();
-      };
-      parent.append(container); reveal();
-      if (visible < values.length) { more.addEventListener('click', reveal); parent.append(more); }
+      const container = node('div');
+      for (const value of values) appendItem(container, value);
+      parent.append(container);
     }
     function renderToolBody(message, callView, resultView) {
       const body = node('div', 'tool-body');
@@ -605,14 +568,14 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         const filePath = string(view.path, 'File'); const title = node('div', 'result-title');
         title.append(filePath === 'File' ? document.createTextNode(filePath) : fileButton(filePath, Number(view.offset) || undefined, filePath)); body.append(title);
         const lines = array(view.lines);
-        if (lines.length) appendPagedItems(body, lines, (container, value) => {
+        if (lines.length) appendItems(body, lines, (container, value) => {
           const line = record(value); if (line) container.append(node('div', 'source-line', String(line.number).padStart(4, ' ') + '  ' + string(line.text)));
-        }, 200);
+        });
         else appendPre(body, message.rawResult);
       } else if (card === 'search') {
-        if (view.shape === 'paths') appendPagedItems(body, array(view.paths), (container, pathValue) => {
+        if (view.shape === 'paths') appendItems(body, array(view.paths), (container, pathValue) => {
           const filePath = string(pathValue); const row = node('div', 'source'); if (filePath) row.append(fileButton(filePath, undefined, filePath)); container.append(row);
-        }, 100);
+        });
         if (view.shape === 'matches') {
           const matches = [];
           for (const fileValue of array(view.files)) {
@@ -620,16 +583,19 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
             matches.push({ kind: 'file', path: filePath });
             for (const matchValue of array(file.matches)) matches.push({ kind: 'match', path: filePath, value: matchValue });
           }
-          appendPagedItems(body, matches, (container, entry) => {
+          appendItems(body, matches, (container, entry) => {
             if (entry.kind === 'file') { const title = node('div', 'result-title'); if (entry.path) title.append(fileButton(entry.path, undefined, entry.path)); container.append(title); return; }
             const match = record(entry.value); if (!match) return; const line = Number(match.lineNumber) || undefined; const row = node('div', 'source');
             if (entry.path) row.append(fileButton(entry.path, line, String(match.lineNumber) + ': ' + string(match.line))); container.append(row);
-          }, 100);
+          });
         }
         if (view.truncated === true) body.append(node('div', '', 'Showing a limited result set (' + String(view.total || '') + ' total).'));
       } else if (card === 'web') {
-        if (typeof view.answer === 'string') appendMarkdownPage(body, view.answer);
-        appendPagedItems(body, array(view.sources), (container, sourceValue) => { const source = record(sourceValue); if (source && typeof source.url === 'string') container.append(link(source.url, string(source.title) || source.url)); }, 50);
+        if (typeof view.answer === 'string') {
+          if (view.plainText === true) body.append(node('div', 'streaming-plain', view.answer));
+          else appendMarkdownPage(body, view.answer);
+        }
+        appendItems(body, array(view.sources), (container, sourceValue) => { const source = record(sourceValue); if (source && typeof source.url === 'string') container.append(link(source.url, string(source.title) || source.url)); });
         if (typeof view.url === 'string') body.append(link(view.url, view.url));
       } else {
         const presented = contentText(view && view.content);
@@ -642,6 +608,62 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       }
       appendImages(body, message.images);
       return body;
+    }
+    function cancelDeferredRequest(messageId) {
+      const request = loadingToolRequests.get(messageId);
+      if (request) clearTimeout(request.timer);
+      loadingToolRequests.delete(messageId);
+    }
+    function resetDeferredOutput(messageId) {
+      cancelDeferredRequest(messageId); toolOutputPages.delete(messageId); toolOutputErrors.delete(messageId); deferredOutputViews.delete(messageId);
+    }
+    function prepareDeferredOutput(message) {
+      const loaded = toolOutputPages.get(message.id);
+      if (loaded && loaded.revision !== message.deferredBodyRevision) resetDeferredOutput(message.id);
+    }
+    function attachDeferredOutput(message, parent, renderPage, autoLoad, initialLabel) {
+      prepareDeferredOutput(message);
+      const pages = node('div'); const controls = node('div'); parent.append(pages, controls);
+      const loaded = toolOutputPages.get(message.id) || { pages: [], nextCursor: undefined, revision: message.deferredBodyRevision };
+      toolOutputPages.set(message.id, loaded);
+      for (const page of loaded.pages) pages.append(renderPage(page));
+      function load(cursor) {
+        if (loadingToolRequests.has(message.id)) return;
+        const requestId = ++toolOutputRequestId;
+        const timer = setTimeout(() => {
+          const pending = loadingToolRequests.get(message.id);
+          if (!pending || pending.requestId !== requestId) return;
+          loadingToolRequests.delete(message.id); toolOutputErrors.set(message.id, { message: 'Output took too long to load.', cursor }); controller.renderControls();
+        }, 15000);
+        loadingToolRequests.set(message.id, { requestId, cursor, timer }); toolOutputErrors.delete(message.id); controller.renderControls();
+        vscode.postMessage({ type: 'load-tool-output', messageId: message.id, sessionId: state && state.sessionId, requestId, ...(cursor ? { cursor } : {}) });
+      }
+      const controller = {
+        revision: message.deferredBodyRevision,
+        append(page, nextCursor) {
+          pages.append(renderPage(page)); loaded.pages.push(page); loaded.nextCursor = nextCursor; controller.renderControls();
+        },
+        renderControls() {
+          controls.replaceChildren();
+          const error = toolOutputErrors.get(message.id);
+          if (error) {
+            controls.append(node('div', 'status error', error.message));
+            const retry = node('button', 'tool-output-more', 'Retry'); retry.type = 'button'; retry.addEventListener('click', () => load(error.cursor)); controls.append(retry); return;
+          }
+          if (loadingToolRequests.has(message.id)) { controls.append(node('div', 'tool-output-loading', 'Loading output…')); return; }
+          if (loaded.pages.length === 0) {
+            if (autoLoad !== false) load(undefined);
+            else {
+              const show = node('button', 'tool-output-more', initialLabel || 'Show output'); show.type = 'button'; show.addEventListener('click', () => load(undefined)); controls.append(show);
+            }
+            return;
+          }
+          if (loaded.nextCursor) {
+            const more = node('button', 'tool-output-more', 'Show more'); more.type = 'button'; more.addEventListener('click', () => load(loaded.nextCursor)); controls.append(more);
+          }
+        },
+      };
+      deferredOutputViews.set(message.id, controller); controller.renderControls();
     }
     function renderTool(message) {
       const callView = record(message.callView);
@@ -659,34 +681,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         if (contentInitialized) return;
         contentInitialized = true;
         if (message.deferredBody === true) {
-          const body = node('div', 'tool-body'); item.append(body);
-          const loaded = toolOutputPages.get(message.id) || { pages: [], nextCursor: undefined };
-          for (const page of loaded.pages) {
-            const callPage = record(page.callView); const resultPage = record(page.resultView);
-            body.append(renderToolBody(page, callPage, resultPage));
-          }
-          const load = cursor => {
-            if (loadingToolRequests.has(message.id)) return;
-            const requestId = ++toolOutputRequestId;
-            const timer = setTimeout(() => {
-              const pending = loadingToolRequests.get(message.id);
-              if (!pending || pending.requestId !== requestId) return;
-              loadingToolRequests.delete(message.id); toolOutputErrors.set(message.id, { message: 'Tool output took too long to load.', cursor }); renderedMessages.delete(message.id);
-              if (state) scheduleRender({ ...state, messages: [...state.messages] });
-            }, 15000);
-            loadingToolRequests.set(message.id, { requestId, cursor, timer }); toolOutputErrors.delete(message.id);
-            const loading = node('div', 'tool-output-loading', 'Loading tool output…'); body.append(loading);
-            vscode.postMessage({ type: 'load-tool-output', messageId: message.id, sessionId: state && state.sessionId, requestId, ...(cursor ? { cursor } : {}) });
-          };
-          const error = toolOutputErrors.get(message.id);
-          if (error) {
-            body.append(node('div', 'status error', error.message));
-            const retry = node('button', 'tool-output-more', 'Retry'); retry.type = 'button'; retry.addEventListener('click', () => load(error.cursor)); body.append(retry);
-          } else if (loadingToolRequests.has(message.id)) body.append(node('div', 'tool-output-loading', 'Loading tool output…'));
-          else if (loaded.pages.length === 0) load(undefined);
-          else if (loaded.nextCursor) {
-            const more = node('button', 'tool-output-more', 'Show more'); more.type = 'button'; more.addEventListener('click', () => load(loaded.nextCursor)); body.append(more);
-          }
+          const body = node('div', 'tool-body'); item.append(body); attachDeferredOutput(message, body, page => renderToolBody(page, record(page.callView), record(page.resultView)));
         } else item.append(renderToolBody(message, callView, resultView));
       };
       if (item.open) initializeContent();
@@ -703,7 +698,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       head.append(node('span', 'command-name', message.text));
       head.append(node('span', 'tool-detail', message.detail || ''));
       item.append(head);
-      if (message.rawResult) { const result = node('div', 'command-result'); appendPre(result, message.rawResult); item.append(result); }
+      if (message.deferredBody === true) {
+        const result = node('div', 'command-result'); item.append(result); attachDeferredOutput(message, result, page => renderToolBody(page, record(page.callView), record(page.resultView)), false, 'Show command output');
+      } else if (message.rawResult) { const result = node('div', 'command-result'); appendPre(result, message.rawResult); item.append(result); }
       return item;
     }
     function renderChangedFiles(groups) {
@@ -733,6 +730,11 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       const body = node('div', 'message-body', item.preview || 'Steering message');
       bubble.append(body); return bubble;
     }
+    function renderAssistantPage(page) {
+      const view = record(page.resultView);
+      const body = view && view.plainText === true ? node('div', 'streaming-plain', page.text) : renderMarkdown(page.text);
+      body.classList.add('assistant-page'); appendImages(body, page.images); return body;
+    }
     function renderMessage(message) {
       if (message.role === 'tool') return { message, node: renderTool(message) };
       if (message.role === 'command') return { message, node: renderCommand(message) };
@@ -742,21 +744,28 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       head.append(node('span', 'avatar' + (message.role === 'assistant' ? ' deepseek-mark' : ''), message.role === 'user' ? 'Y' : ''));
       head.append(node('span', '', message.role === 'user' ? 'You' : 'DeepSeek'));
       const markdown = message.role === 'assistant' && message.streaming === true ? createMarkdownStream(message.text) : undefined;
-      const body = message.role === 'assistant' ? (markdown ? markdown.root : renderMarkdown(message.text)) : node('div', '', message.text);
+      const body = message.role === 'assistant'
+        ? message.deferredBody === true ? node('div', 'markdown') : (markdown ? markdown.root : renderMarkdown(message.text))
+        : node('div', '', message.text);
       body.classList.add('message-body');
       if (message.streaming) body.classList.add('streaming');
-      appendImages(body, message.images);
+      if (message.deferredBody === true) attachDeferredOutput(message, body, renderAssistantPage, false, 'Show full response' + (message.bodyLength ? ' · ' + String(message.bodyLength) + ' characters' : ''));
+      else appendImages(body, message.images);
       item.append(head, body); return { message, node: item, ...(markdown ? { markdown } : {}) };
     }
     function messageNode(message) {
       const rendered = renderedMessages.get(message.id);
       if (rendered && rendered.message === message) return rendered.node;
-      if (rendered && rendered.markdown && message.role === 'assistant' && message.images === rendered.message.images && updateMarkdownStream(rendered.markdown, message.text, message.streaming === true)) {
+      if (rendered && rendered.message.deferredBodyRevision !== message.deferredBodyRevision) resetDeferredOutput(message.id);
+      const appended = pendingMessageAppends.get(message.id);
+      if (rendered && rendered.markdown && appended !== undefined && message.role === 'assistant' && message.images === rendered.message.images) {
+        pendingMessageAppends.delete(message.id); appendMarkdownStream(rendered.markdown, appended, message.streaming === true);
         rendered.message = message;
         rendered.markdown.root.classList.toggle('streaming', message.streaming === true);
         return rendered.node;
       }
       const next = renderMessage(message);
+      if (rendered) deferredOutputViews.delete(message.id);
       if (rendered && rendered.node.isConnected) rendered.node.replaceWith(next.node);
       renderedMessages.set(message.id, next);
       return next.node;
@@ -768,8 +777,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       const ids = new Set(messages.map(message => message.id));
       for (const [id, rendered] of renderedMessages) {
         if (!ids.has(id)) {
-          rendered.node.remove(); renderedMessages.delete(id); expandedToolIds.delete(id); toolOutputPages.delete(id); toolOutputErrors.delete(id);
-          const request = loadingToolRequests.get(id); if (request) clearTimeout(request.timer); loadingToolRequests.delete(id);
+          rendered.node.remove(); renderedMessages.delete(id); expandedToolIds.delete(id); resetDeferredOutput(id); pendingMessageAppends.delete(id);
         }
       }
       let cursor = elements.messages.firstChild;
@@ -1269,7 +1277,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
         renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear();
         for (const request of loadingToolRequests.values()) clearTimeout(request.timer);
-        loadingToolRequests.clear(); toolOutputErrors.clear(); toolOutputPages.clear();
+        loadingToolRequests.clear(); toolOutputErrors.clear(); toolOutputPages.clear(); deferredOutputViews.clear(); pendingMessageAppends.clear();
       }
       const statusKey = current.phase + '::' + current.statusText;
       if (statusKey !== renderedStatusKey) {
@@ -1350,10 +1358,11 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       });
     }
     function applyMessagesPatch(current, patch) {
-      if (Array.isArray(patch && patch.reset)) return patch.reset;
+      if (Array.isArray(patch && patch.reset)) { pendingMessageAppends.clear(); return patch.reset; }
       const messages = Array.isArray(current) ? [...current] : [];
       const indexes = new Map(messages.map((message, index) => [message.id, index]));
       for (const message of array(patch && patch.upserts)) {
+        pendingMessageAppends.delete(message.id);
         const index = indexes.get(message.id);
         if (index === undefined) { indexes.set(message.id, messages.length); messages.push(message); }
         else messages[index] = message;
@@ -1361,6 +1370,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       for (const append of array(patch && patch.appends)) {
         const index = indexes.get(append.id); const message = index === undefined ? undefined : messages[index];
         if (!message || message.role !== 'assistant') continue;
+        pendingMessageAppends.set(append.id, string(pendingMessageAppends.get(append.id)) + string(append.text));
         messages[index] = { ...message, text: message.text + string(append.text), streaming: append.streaming === true };
       }
       return messages;
@@ -1434,21 +1444,25 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     });
     window.addEventListener('message', event => {
       if (!event.data) return;
-      if (event.data.type === 'state') scheduleRender(event.data.state);
+      if (event.data.type === 'state') { pendingMessageAppends.clear(); scheduleRender(event.data.state); }
       if (event.data.type === 'state-update') applyStateUpdate(event.data.update);
       if (event.data.type === 'tool-output' && state && event.data.sessionId === state.sessionId && typeof event.data.messageId === 'string') {
         const request = loadingToolRequests.get(event.data.messageId);
         if (!request || request.requestId !== event.data.requestId) return;
         clearTimeout(request.timer); loadingToolRequests.delete(event.data.messageId);
         if (typeof event.data.error === 'string') {
-          toolOutputErrors.set(event.data.messageId, { message: event.data.error, cursor: request.cursor }); renderedMessages.delete(event.data.messageId);
-          scheduleRender({ ...state, messages: [...state.messages] }); return;
+          toolOutputErrors.set(event.data.messageId, { message: event.data.error, cursor: request.cursor });
+          const controller = deferredOutputViews.get(event.data.messageId); if (controller) controller.renderControls(); return;
         }
         toolOutputErrors.delete(event.data.messageId);
         if (event.data.page && event.data.page.message) {
-          const loaded = toolOutputPages.get(event.data.messageId) || { pages: [], nextCursor: undefined };
-          toolOutputPages.set(event.data.messageId, { pages: [...loaded.pages, event.data.page.message], nextCursor: event.data.page.nextCursor });
-          renderedMessages.delete(event.data.messageId); scheduleRender({ ...state, messages: [...state.messages] });
+          const controller = deferredOutputViews.get(event.data.messageId);
+          if (controller) controller.append(event.data.page.message, event.data.page.nextCursor);
+          else {
+            const message = array(state.messages).find(candidate => candidate.id === event.data.messageId);
+            const loaded = toolOutputPages.get(event.data.messageId) || { pages: [], nextCursor: undefined, revision: message && message.deferredBodyRevision };
+            loaded.pages.push(event.data.page.message); loaded.nextCursor = event.data.page.nextCursor; toolOutputPages.set(event.data.messageId, loaded);
+          }
         }
       }
       if (event.data.type === 'draft-images') { draftImages = event.data.images || []; renderAttachments(); }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -19,8 +19,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${token}';">
-  <style>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${webview.cspSource} data:; style-src ${webview.cspSource} 'nonce-${token}'; script-src 'nonce-${token}';">
+  <style nonce="${token}">
     :root { color-scheme: light dark; }
     * { box-sizing: border-box; }
     html, body { width: 100%; height: 100%; margin: 0; overflow: hidden; }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -317,6 +317,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     const expandedToolIds = new Set();
     const loadingToolRequests = new Map();
     const toolOutputErrors = new Map();
+    const toolOutputPages = new Map();
     let toolOutputRequestId = 0;
     const toolOutputChunkSize = 20000;
 
@@ -659,18 +660,33 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         contentInitialized = true;
         if (message.deferredBody === true) {
           const body = node('div', 'tool-body'); item.append(body);
-          const load = () => {
+          const loaded = toolOutputPages.get(message.id) || { pages: [], nextCursor: undefined };
+          for (const page of loaded.pages) {
+            const callPage = record(page.callView); const resultPage = record(page.resultView);
+            body.append(renderToolBody(page, callPage, resultPage));
+          }
+          const load = cursor => {
+            if (loadingToolRequests.has(message.id)) return;
             const requestId = ++toolOutputRequestId;
-            loadingToolRequests.set(message.id, requestId); toolOutputErrors.delete(message.id);
-            body.replaceChildren(node('div', '', 'Loading tool output…'));
-            vscode.postMessage({ type: 'load-tool-output', messageId: message.id, sessionId: state && state.sessionId, requestId });
+            const timer = setTimeout(() => {
+              const pending = loadingToolRequests.get(message.id);
+              if (!pending || pending.requestId !== requestId) return;
+              loadingToolRequests.delete(message.id); toolOutputErrors.set(message.id, { message: 'Tool output took too long to load.', cursor }); renderedMessages.delete(message.id);
+              if (state) scheduleRender({ ...state, messages: [...state.messages] });
+            }, 15000);
+            loadingToolRequests.set(message.id, { requestId, cursor, timer }); toolOutputErrors.delete(message.id);
+            const loading = node('div', 'tool-output-loading', 'Loading tool output…'); body.append(loading);
+            vscode.postMessage({ type: 'load-tool-output', messageId: message.id, sessionId: state && state.sessionId, requestId, ...(cursor ? { cursor } : {}) });
           };
           const error = toolOutputErrors.get(message.id);
           if (error) {
-            body.append(node('div', 'status error', error));
-            const retry = node('button', 'tool-output-more', 'Retry'); retry.type = 'button'; retry.addEventListener('click', load); body.append(retry);
-          } else if (!loadingToolRequests.has(message.id)) load();
-          else body.append(node('div', '', 'Loading tool output…'));
+            body.append(node('div', 'status error', error.message));
+            const retry = node('button', 'tool-output-more', 'Retry'); retry.type = 'button'; retry.addEventListener('click', () => load(error.cursor)); body.append(retry);
+          } else if (loadingToolRequests.has(message.id)) body.append(node('div', 'tool-output-loading', 'Loading tool output…'));
+          else if (loaded.pages.length === 0) load(undefined);
+          else if (loaded.nextCursor) {
+            const more = node('button', 'tool-output-more', 'Show more'); more.type = 'button'; more.addEventListener('click', () => load(loaded.nextCursor)); body.append(more);
+          }
         } else item.append(renderToolBody(message, callView, resultView));
       };
       if (item.open) initializeContent();
@@ -751,7 +767,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       }
       const ids = new Set(messages.map(message => message.id));
       for (const [id, rendered] of renderedMessages) {
-        if (!ids.has(id)) { rendered.node.remove(); renderedMessages.delete(id); }
+        if (!ids.has(id)) {
+          rendered.node.remove(); renderedMessages.delete(id); expandedToolIds.delete(id); toolOutputPages.delete(id); toolOutputErrors.delete(id);
+          const request = loadingToolRequests.get(id); if (request) clearTimeout(request.timer); loadingToolRequests.delete(id);
+        }
       }
       let cursor = elements.messages.firstChild;
       for (const message of messages) {
@@ -1248,7 +1267,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function renderConversation(current) {
       if (renderedSessionId !== current.sessionId) {
         renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
-        renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear(); loadingToolRequests.clear(); toolOutputErrors.clear();
+        renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear();
+        for (const request of loadingToolRequests.values()) clearTimeout(request.timer);
+        loadingToolRequests.clear(); toolOutputErrors.clear(); toolOutputPages.clear();
       }
       const statusKey = current.phase + '::' + current.statusText;
       if (statusKey !== renderedStatusKey) {
@@ -1416,14 +1437,19 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (event.data.type === 'state') scheduleRender(event.data.state);
       if (event.data.type === 'state-update') applyStateUpdate(event.data.update);
       if (event.data.type === 'tool-output' && state && event.data.sessionId === state.sessionId && typeof event.data.messageId === 'string') {
-        if (loadingToolRequests.get(event.data.messageId) !== event.data.requestId) return;
-        loadingToolRequests.delete(event.data.messageId);
+        const request = loadingToolRequests.get(event.data.messageId);
+        if (!request || request.requestId !== event.data.requestId) return;
+        clearTimeout(request.timer); loadingToolRequests.delete(event.data.messageId);
         if (typeof event.data.error === 'string') {
-          toolOutputErrors.set(event.data.messageId, event.data.error); renderedMessages.delete(event.data.messageId);
+          toolOutputErrors.set(event.data.messageId, { message: event.data.error, cursor: request.cursor }); renderedMessages.delete(event.data.messageId);
           scheduleRender({ ...state, messages: [...state.messages] }); return;
         }
         toolOutputErrors.delete(event.data.messageId);
-        if (event.data.message) scheduleRender({ ...state, messages: applyMessagesPatch(state.messages, { upserts: [event.data.message] }) });
+        if (event.data.page && event.data.page.message) {
+          const loaded = toolOutputPages.get(event.data.messageId) || { pages: [], nextCursor: undefined };
+          toolOutputPages.set(event.data.messageId, { pages: [...loaded.pages, event.data.page.message], nextCursor: event.data.page.nextCursor });
+          renderedMessages.delete(event.data.messageId); scheduleRender({ ...state, messages: [...state.messages] });
+        }
       }
       if (event.data.type === 'draft-images') { draftImages = event.data.images || []; renderAttachments(); }
       if (event.data.type === 'ide-context') { ideContext = event.data.state || { pinned: [] }; renderIdeContext(); }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -49,6 +49,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     svg { width: 17px; height: 17px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
     .scroll { min-width: 0; min-height: 0; overflow-x: hidden; overflow-y: auto; scrollbar-color: var(--vscode-scrollbarSlider-background) transparent; }
     .conversation { width: 100%; min-width: 0; max-width: 760px; margin: 0 auto; padding: 12px 14px 30px; overflow: hidden; }
+    .conversation-slot, .messages { display: contents; }
     .history-loader { display: flex; justify-content: center; padding: 1px 0 9px; }
     .history-button { padding: 3px 9px; border: 0; border-radius: 5px; color: var(--vscode-textLink-foreground); background: transparent; font-size: 11px; }
     .history-button:hover { background: var(--vscode-toolbar-hoverBackground); }
@@ -236,7 +237,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       </div>
       <button id="newSession" class="icon-button" title="New conversation" aria-label="New conversation"><svg viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg></button>
     </header>
-    <main id="scroll" class="scroll"><div id="conversation" class="conversation"></div></main>
+    <main id="scroll" class="scroll"><div id="conversation" class="conversation"><div id="conversationStatus" class="conversation-slot"></div><div id="conversationHistory" class="conversation-slot"></div><div id="messages" class="messages"></div><div id="conversationTail" class="conversation-slot"></div></div></main>
     <footer class="composer-wrap">
       <div id="queueDock" class="queue-dock hidden" aria-label="Queued messages"></div>
       <div class="composer">
@@ -277,6 +278,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     });
     const elements = {
       conversation: document.getElementById('conversation'), scroll: document.getElementById('scroll'),
+      conversationStatus: document.getElementById('conversationStatus'), conversationHistory: document.getElementById('conversationHistory'), messages: document.getElementById('messages'), conversationTail: document.getElementById('conversationTail'),
       sessions: document.getElementById('sessions'), newSession: document.getElementById('newSession'), jobsControl: document.getElementById('jobsControl'), jobsTrigger: document.getElementById('jobsTrigger'), jobsCount: document.getElementById('jobsCount'), jobsMenu: document.getElementById('jobsMenu'),
       prompt: document.getElementById('prompt'), project: document.getElementById('project'), workspace: document.getElementById('workspace'),
       models: document.getElementById('models'), efforts: document.getElementById('efforts'),
@@ -301,6 +303,13 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let jobsOpen = false;
     let jobsTimer;
     let historyAnchor;
+    let renderFrame;
+    let pendingRenderState;
+    let renderedSessionId;
+    let renderedStatusKey = '';
+    let renderedHistoryKey = '';
+    let renderedTail = {};
+    const renderedMessages = new Map();
 
     function node(tag, className, text) {
       const value = document.createElement(tag);
@@ -567,6 +576,30 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (message.streaming) body.classList.add('streaming');
       appendImages(body, message.images);
       item.append(head, body); return item;
+    }
+    function messageNode(message) {
+      const rendered = renderedMessages.get(message.id);
+      if (rendered && rendered.message === message) return rendered.node;
+      const next = renderMessage(message);
+      if (rendered && rendered.node.isConnected) rendered.node.replaceWith(next);
+      renderedMessages.set(message.id, { message, node: next });
+      return next;
+    }
+    function reconcileMessages(messages, current) {
+      if (!messages.length) {
+        renderedMessages.clear(); elements.messages.replaceChildren(renderEmpty(current)); return;
+      }
+      const ids = new Set(messages.map(message => message.id));
+      for (const [id, rendered] of renderedMessages) {
+        if (!ids.has(id)) { rendered.node.remove(); renderedMessages.delete(id); }
+      }
+      let cursor = elements.messages.firstChild;
+      for (const message of messages) {
+        const desired = messageNode(message);
+        if (desired === cursor) cursor = cursor.nextSibling;
+        else elements.messages.insertBefore(desired, cursor);
+      }
+      while (cursor) { const next = cursor.nextSibling; cursor.remove(); cursor = next; }
     }
     function renderStatus(current) {
       const box = node('div', 'status' + (current.phase === 'error' ? ' error' : ''), current.statusText || 'Starting DeepSeek Harness…');
@@ -1052,6 +1085,41 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (jobsTimer) { clearInterval(jobsTimer); jobsTimer = undefined; }
       if (jobsOpen && live > 0) jobsTimer = setInterval(renderJobs, 1000);
     }
+    function renderConversation(current) {
+      if (renderedSessionId !== current.sessionId) {
+        renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
+        renderedHistoryKey = ''; renderedTail = {};
+      }
+      const statusKey = current.phase + '::' + current.statusText;
+      if (statusKey !== renderedStatusKey) {
+        renderedStatusKey = statusKey;
+        elements.conversationStatus.replaceChildren();
+        if (current.phase !== 'ready') elements.conversationStatus.append(renderStatus(current));
+      }
+      if (current.phase !== 'ready') {
+        elements.conversationHistory.replaceChildren(); elements.messages.replaceChildren(); elements.conversationTail.replaceChildren();
+        return;
+      }
+
+      const historyKey = String(current.hasMoreHistory) + '::' + String(current.loadingHistory);
+      if (historyKey !== renderedHistoryKey) {
+        renderedHistoryKey = historyKey; elements.conversationHistory.replaceChildren();
+        if (current.hasMoreHistory || current.loadingHistory) {
+          const loader = node('div', 'history-loader'); const button = node('button', 'history-button', current.loadingHistory ? 'Loading earlier messages…' : 'Load earlier messages'); button.type = 'button'; button.disabled = current.loadingHistory === true;
+          button.addEventListener('click', () => { historyAnchor = { sessionId: current.sessionId, height: elements.scroll.scrollHeight, top: elements.scroll.scrollTop }; button.disabled = true; button.textContent = 'Loading earlier messages…'; vscode.postMessage({ type: 'load-history' }); }); loader.append(button); elements.conversationHistory.append(loader);
+        }
+      }
+      reconcileMessages(array(current.messages), current);
+
+      if (renderedTail.queue !== current.queue || renderedTail.changedFiles !== current.changedFiles || renderedTail.approval !== current.approval || renderedTail.question !== current.question) {
+        renderedTail = { queue: current.queue, changedFiles: current.changedFiles, approval: current.approval, question: current.question };
+        elements.conversationTail.replaceChildren();
+        for (const item of current.queue || []) if (item.placement === 'steering') elements.conversationTail.append(renderPendingSteering(item));
+        if (current.changedFiles && current.changedFiles.length) elements.conversationTail.append(renderChangedFiles(current.changedFiles));
+        if (current.approval) elements.conversationTail.append(renderApproval(current.approval));
+        if (current.question) elements.conversationTail.append(renderQuestions(current.question));
+      }
+    }
     function render(current) {
       const nearBottom = elements.scroll.scrollHeight - elements.scroll.scrollTop - elements.scroll.clientHeight < 80;
       const preservingHistory = historyAnchor && historyAnchor.sessionId === current.sessionId;
@@ -1066,20 +1134,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       renderPolicyState(current);
       renderUsage(current);
       renderJobs();
-      elements.conversation.replaceChildren();
-      if (current.phase !== 'ready') elements.conversation.append(renderStatus(current));
-      else {
-        if (current.hasMoreHistory || current.loadingHistory) {
-          const loader = node('div', 'history-loader'); const button = node('button', 'history-button', current.loadingHistory ? 'Loading earlier messages…' : 'Load earlier messages'); button.type = 'button'; button.disabled = current.loadingHistory === true;
-          button.addEventListener('click', () => { historyAnchor = { sessionId: current.sessionId, height: elements.scroll.scrollHeight, top: elements.scroll.scrollTop }; button.disabled = true; button.textContent = 'Loading earlier messages…'; vscode.postMessage({ type: 'load-history' }); }); loader.append(button); elements.conversation.append(loader);
-        }
-        if (!current.messages || current.messages.length === 0) elements.conversation.append(renderEmpty(current));
-        else for (const message of current.messages) elements.conversation.append(renderMessage(message));
-        for (const item of current.queue || []) if (item.placement === 'steering') elements.conversation.append(renderPendingSteering(item));
-        if (current.changedFiles && current.changedFiles.length) elements.conversation.append(renderChangedFiles(current.changedFiles));
-        if (current.approval) elements.conversation.append(renderApproval(current.approval));
-        if (current.question) elements.conversation.append(renderQuestions(current.question));
-      }
+      renderConversation(current);
       const enabled = current.phase === 'ready' && current.routable !== false && Boolean(current.sessionId);
       elements.prompt.disabled = !enabled; elements.attach.disabled = !enabled; elements.project.disabled = current.running === true; elements.newSession.disabled = current.phase !== 'ready'; elements.sessions.disabled = current.phase !== 'ready';
       elements.models.disabled = !enabled || !(current.models || []).length; elements.efforts.disabled = !enabled || !elements.efforts.options.length || elements.efforts.value === '';
@@ -1089,6 +1144,15 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         const anchor = historyAnchor; historyAnchor = undefined;
         requestAnimationFrame(() => { elements.scroll.scrollTop = anchor.top + elements.scroll.scrollHeight - anchor.height; });
       } else if (!preservingHistory && (nearBottom || current.approval || current.question)) requestAnimationFrame(() => { elements.scroll.scrollTop = elements.scroll.scrollHeight; });
+    }
+    function scheduleRender(current) {
+      state = current; pendingRenderState = current;
+      if (renderFrame !== undefined) return;
+      renderFrame = requestAnimationFrame(() => {
+        renderFrame = undefined;
+        const pending = pendingRenderState; pendingRenderState = undefined;
+        if (pending) render(pending);
+      });
     }
     function applyMessagesPatch(current, patch) {
       if (Array.isArray(patch && patch.reset)) return patch.reset;
@@ -1107,7 +1171,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       const messages = update && update.messages
         ? applyMessagesPatch(state.messages, update.messages)
         : state.messages;
-      render({ ...state, ...patch, messages });
+      scheduleRender({ ...state, ...patch, messages });
     }
     function updateSend() { elements.send.disabled = !state || state.phase !== 'ready' || (elements.prompt.value.trim() === '' && draftImages.length === 0); }
     function resizePrompt() { elements.prompt.style.height = 'auto'; elements.prompt.style.height = Math.min(elements.prompt.scrollHeight, 220) + 'px'; updateSend(); }
@@ -1170,7 +1234,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     });
     window.addEventListener('message', event => {
       if (!event.data) return;
-      if (event.data.type === 'state') render(event.data.state);
+      if (event.data.type === 'state') scheduleRender(event.data.state);
       if (event.data.type === 'state-update') applyStateUpdate(event.data.update);
       if (event.data.type === 'draft-images') { draftImages = event.data.images || []; renderAttachments(); }
       if (event.data.type === 'ide-context') { ideContext = event.data.state || { pinned: [] }; renderIdeContext(); }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1090,6 +1090,25 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         requestAnimationFrame(() => { elements.scroll.scrollTop = anchor.top + elements.scroll.scrollHeight - anchor.height; });
       } else if (!preservingHistory && (nearBottom || current.approval || current.question)) requestAnimationFrame(() => { elements.scroll.scrollTop = elements.scroll.scrollHeight; });
     }
+    function applyMessagesPatch(current, patch) {
+      if (Array.isArray(patch && patch.reset)) return patch.reset;
+      const messages = Array.isArray(current) ? [...current] : [];
+      const indexes = new Map(messages.map((message, index) => [message.id, index]));
+      for (const message of array(patch && patch.upserts)) {
+        const index = indexes.get(message.id);
+        if (index === undefined) { indexes.set(message.id, messages.length); messages.push(message); }
+        else messages[index] = message;
+      }
+      return messages;
+    }
+    function applyStateUpdate(update) {
+      if (!state) return;
+      const patch = record(update && update.patch) || {};
+      const messages = update && update.messages
+        ? applyMessagesPatch(state.messages, update.messages)
+        : state.messages;
+      render({ ...state, ...patch, messages });
+    }
     function updateSend() { elements.send.disabled = !state || state.phase !== 'ready' || (elements.prompt.value.trim() === '' && draftImages.length === 0); }
     function resizePrompt() { elements.prompt.style.height = 'auto'; elements.prompt.style.height = Math.min(elements.prompt.scrollHeight, 220) + 'px'; updateSend(); }
     function selectionFor(model, reasoningEffort) { return { provider: model.provider, model: model.model, ...(reasoningEffort ? { reasoningEffort } : {}) }; }
@@ -1152,6 +1171,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     window.addEventListener('message', event => {
       if (!event.data) return;
       if (event.data.type === 'state') render(event.data.state);
+      if (event.data.type === 'state-update') applyStateUpdate(event.data.update);
       if (event.data.type === 'draft-images') { draftImages = event.data.images || []; renderAttachments(); }
       if (event.data.type === 'ide-context') { ideContext = event.data.state || { pinned: [] }; renderIdeContext(); }
       if (event.data.type === 'mention-suggestions' && event.data.requestId === mentionRequestId) {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -98,6 +98,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     .tool-detail { color: var(--vscode-descriptionForeground); font-size: 11px; }
     .tool-body { padding: 0 10px 9px 34px; min-width: 0; overflow: hidden; color: var(--vscode-descriptionForeground); }
     .tool-body pre { color: var(--vscode-foreground); }
+    .tool-output-more { margin: 5px 0 0; padding: 2px 7px; border: 1px solid var(--vscode-widget-border); border-radius: 5px; color: var(--vscode-textLink-foreground); background: transparent; font-size: 11px; }
+    .tool-output-more:hover { background: var(--vscode-toolbar-hoverBackground); }
     .command-card { margin: 7px 0 10px; padding: 8px 10px; border: 1px solid var(--vscode-widget-border); border-radius: 8px; background: color-mix(in srgb, var(--vscode-editor-background) 72%, transparent); }
     .command-card.failed { border-color: var(--vscode-errorForeground); }
     .command-head { min-width: 0; display: flex; align-items: center; gap: 7px; }
@@ -310,6 +312,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let renderedHistoryKey = '';
     let renderedTail = {};
     const renderedMessages = new Map();
+    const expandedToolIds = new Set();
+    const loadingToolIds = new Set();
+    const toolOutputChunkSize = 20000;
 
     function node(tag, className, text) {
       const value = document.createElement(tag);
@@ -447,7 +452,20 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       }
       if (gallery.childNodes.length) parent.append(gallery);
     }
-    function appendPre(parent, text, className) { if (text) parent.append(node('pre', className || '', text)); }
+    function appendPre(parent, text, className) {
+      if (!text) return;
+      const value = String(text); let visible = Math.min(value.length, toolOutputChunkSize);
+      const pre = node('pre', className || '', value.slice(0, visible)); parent.append(pre);
+      if (visible >= value.length) return;
+      const more = node('button', 'tool-output-more'); more.type = 'button';
+      const updateLabel = () => { more.textContent = 'Show more · ' + String(visible) + ' / ' + String(value.length) + ' characters'; };
+      updateLabel();
+      more.addEventListener('click', () => {
+        visible = Math.min(value.length, visible + toolOutputChunkSize); pre.textContent = value.slice(0, visible);
+        if (visible >= value.length) more.remove(); else updateLabel();
+      });
+      parent.append(more);
+    }
     function renderToolBody(message, callView, resultView) {
       const body = node('div', 'tool-body');
       const view = resultView || callView;
@@ -503,8 +521,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         if (typeof view.url === 'string') body.append(link(view.url, view.url));
       } else {
         const presented = contentText(view && view.content);
-        const raw = presented || message.rawResult || (view && view.rawInput !== undefined ? pretty(view.rawInput) : '') || message.rawInput || '';
-        if (raw) appendPre(body, pretty(raw));
+        const raw = presented || message.rawResult || message.rawInput || (view && view.rawInput !== undefined ? view.rawInput : '');
+        if (raw) appendPre(body, typeof raw === 'string' && raw.length > toolOutputChunkSize ? raw : pretty(raw));
         for (const locationValue of array(callView && callView.locations)) {
           const location = record(locationValue); if (!location) continue; const filePath = string(location.path); const line = Number(location.line) || undefined; const row = node('div', 'source');
           if (filePath) row.append(fileButton(filePath, line, filePath + (line ? ':' + String(line) : ''))); body.append(row);
@@ -518,12 +536,28 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       const resultView = record(message.resultView);
       const item = document.createElement('details');
       item.className = 'tool' + (message.failed ? ' failed' : '');
-      item.open = message.streaming === true || message.failed === true;
+      item.open = message.streaming === true || message.failed === true || expandedToolIds.has(message.id);
       const summary = document.createElement('summary');
       summary.append(node('span', 'tool-icon', message.streaming ? '●' : (message.failed ? '!' : '✓')));
       summary.append(node('span', 'tool-title', toolTitle(message, callView, resultView)));
       summary.append(node('span', 'tool-detail', message.detail || ''));
-      item.append(summary, renderToolBody(message, callView, resultView));
+      item.append(summary);
+      let contentInitialized = false;
+      const initializeContent = () => {
+        if (contentInitialized) return;
+        contentInitialized = true;
+        if (message.deferredBody === true) {
+          item.append(node('div', 'tool-body', 'Loading tool output…'));
+          if (!loadingToolIds.has(message.id)) {
+            loadingToolIds.add(message.id); vscode.postMessage({ type: 'load-tool-output', messageId: message.id });
+          }
+        } else item.append(renderToolBody(message, callView, resultView));
+      };
+      if (item.open) initializeContent();
+      item.addEventListener('toggle', () => {
+        if (item.open) { expandedToolIds.add(message.id); initializeContent(); }
+        else expandedToolIds.delete(message.id);
+      });
       return item;
     }
     function renderCommand(message) {
@@ -1088,7 +1122,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function renderConversation(current) {
       if (renderedSessionId !== current.sessionId) {
         renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
-        renderedHistoryKey = ''; renderedTail = {};
+        renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear(); loadingToolIds.clear();
       }
       const statusKey = current.phase + '::' + current.statusText;
       if (statusKey !== renderedStatusKey) {
@@ -1236,6 +1270,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (!event.data) return;
       if (event.data.type === 'state') scheduleRender(event.data.state);
       if (event.data.type === 'state-update') applyStateUpdate(event.data.update);
+      if (event.data.type === 'tool-output' && state && event.data.sessionId === state.sessionId && event.data.message) {
+        loadingToolIds.delete(event.data.message.id);
+        scheduleRender({ ...state, messages: applyMessagesPatch(state.messages, { upserts: [event.data.message] }) });
+      }
       if (event.data.type === 'draft-images') { draftImages = event.data.images || []; renderAttachments(); }
       if (event.data.type === 'ide-context') { ideContext = event.data.state || { pinned: [] }; renderIdeContext(); }
       if (event.data.type === 'mention-suggestions' && event.data.requestId === mentionRequestId) {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -517,10 +517,12 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (!text) return;
       parent.append(node('pre', className || '', String(text)));
     }
-    function appendPrefixedPre(parent, text, prefix, className) {
+    function appendPrefixedPre(parent, text, prefix, className, continuation) {
       const value = String(text || '');
       if (!value) return;
-      parent.append(node('pre', className || '', prefix + value.replace(/\\n/g, '\\n' + prefix)));
+      const element = node('pre', className || '', (continuation ? '' : prefix) + value.replace(/\\n/g, '\\n' + prefix));
+      if (continuation) element.dataset.diffContinuation = 'true';
+      parent.append(element);
     }
     function appendMarkdownPage(parent, text) {
       const value = String(text || '');
@@ -547,12 +549,15 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         for (const diffValue of array(view.diffs)) {
           const diff = record(diffValue); if (!diff) continue;
           const filePath = string(diff.path, 'File change');
-          if (filePath !== 'File change' && !paths.includes(filePath)) paths.push(filePath);
-          const pathRow = node('div', 'diff-path');
-          pathRow.append(filePath === 'File change' ? document.createTextNode(filePath) : fileButton(filePath, undefined, filePath));
-          body.append(pathRow);
-          if (typeof diff.oldText === 'string') appendPrefixedPre(body, diff.oldText, '- ', 'diff-old');
-          appendPrefixedPre(body, string(diff.newText), '+ ', 'diff-new');
+          const continuation = diff.continuation === true;
+          if (!continuation) {
+            if (filePath !== 'File change' && !paths.includes(filePath)) paths.push(filePath);
+            const pathRow = node('div', 'diff-path');
+            pathRow.append(filePath === 'File change' ? document.createTextNode(filePath) : fileButton(filePath, undefined, filePath));
+            body.append(pathRow);
+          }
+          if (typeof diff.oldText === 'string') appendPrefixedPre(body, diff.oldText, '- ', 'diff-old', continuation);
+          appendPrefixedPre(body, string(diff.newText), '+ ', 'diff-new', continuation);
         }
         for (const filePath of paths) {
           const actions = node('div', 'tool-actions');
@@ -621,12 +626,23 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       const loaded = toolOutputPages.get(message.id);
       if (loaded && loaded.revision !== message.deferredBodyRevision) resetDeferredOutput(message.id);
     }
+    function appendDeferredPage(parent, page, renderPage) {
+      const rendered = renderPage(page);
+      const continuation = rendered.querySelector('pre[data-diff-continuation="true"]');
+      if (continuation) {
+        const selector = continuation.classList.contains('diff-old') ? 'pre.diff-old' : 'pre.diff-new';
+        const candidates = parent.querySelectorAll(selector);
+        const target = candidates[candidates.length - 1];
+        if (target) { target.textContent += continuation.textContent; return; }
+      }
+      parent.append(rendered);
+    }
     function attachDeferredOutput(message, parent, renderPage, autoLoad, initialLabel) {
       prepareDeferredOutput(message);
       const pages = node('div'); const controls = node('div'); parent.append(pages, controls);
       const loaded = toolOutputPages.get(message.id) || { pages: [], nextCursor: undefined, revision: message.deferredBodyRevision };
       toolOutputPages.set(message.id, loaded);
-      for (const page of loaded.pages) pages.append(renderPage(page));
+      for (const page of loaded.pages) appendDeferredPage(pages, page, renderPage);
       function load(cursor) {
         if (loadingToolRequests.has(message.id)) return;
         const requestId = ++toolOutputRequestId;
@@ -641,7 +657,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       const controller = {
         revision: message.deferredBodyRevision,
         append(page, nextCursor) {
-          pages.append(renderPage(page)); loaded.pages.push(page); loaded.nextCursor = nextCursor; controller.renderControls();
+          appendDeferredPage(pages, page, renderPage); loaded.pages.push(page); loaded.nextCursor = nextCursor; controller.renderControls();
         },
         renderControls() {
           controls.replaceChildren();

--- a/tests/chat-state-patch.spec.ts
+++ b/tests/chat-state-patch.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { diffConversationMessages } from '../src/chat-state-patch.js'
+import type { ConversationMessage } from '../src/conversation.js'
+
+function message(id: string, text: string, extra: Partial<ConversationMessage> = {}): ConversationMessage {
+  return { id, role: 'assistant', text, ...extra }
+}
+
+describe('diffConversationMessages', () => {
+  it('sends only the streaming message that changed', () => {
+    const previous = [message('tool:1', 'Tool', { role: 'tool', rawResult: 'large output' }), message('assistant:1', 'Hel', { streaming: true })]
+    const next = [message('tool:1', 'Tool', { role: 'tool', rawResult: 'large output' }), message('assistant:1', 'Hello', { streaming: true })]
+
+    expect(diffConversationMessages(previous, next)).toEqual({ upserts: [next[1]] })
+  })
+
+  it('appends new messages without resetting existing output', () => {
+    const previous = [message('assistant:1', 'Done')]
+    const next = [...previous, message('assistant:2', 'Next', { streaming: true })]
+
+    expect(diffConversationMessages(previous, next)).toEqual({ upserts: [next[1]] })
+  })
+
+  it('treats equivalent image projections as unchanged', () => {
+    const images = [{ attachmentId: 'image-1', mediaType: 'image/png' as const, width: 20, height: 10, data: 'abc' }]
+    const previous = [message('assistant:1', '', { images })]
+    const next = [message('assistant:1', '', { images: images.map(image => ({ ...image })) })]
+
+    expect(diffConversationMessages(previous, next)).toBeUndefined()
+  })
+
+  it('resets when history is inserted before existing messages', () => {
+    const previous = [message('assistant:2', 'Current')]
+    const next = [message('assistant:1', 'Earlier'), ...previous]
+
+    expect(diffConversationMessages(previous, next)).toEqual({ reset: next })
+  })
+})

--- a/tests/chat-state-patch.spec.ts
+++ b/tests/chat-state-patch.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { diffConversationMessages } from '../src/chat-state-patch.js'
+import { diffConversationMessages, messageForWebview, messagesPatchForWebview } from '../src/chat-state-patch.js'
 import type { ConversationMessage } from '../src/conversation.js'
 
 function message(id: string, text: string, extra: Partial<ConversationMessage> = {}): ConversationMessage {
@@ -34,5 +34,34 @@ describe('diffConversationMessages', () => {
     const next = [message('assistant:1', 'Earlier'), ...previous]
 
     expect(diffConversationMessages(previous, next)).toEqual({ reset: next })
+  })
+
+  it('defers completed tool bodies while preserving their summary', () => {
+    const tool = message('tool:large', 'mcp_router_status', {
+      role: 'tool',
+      detail: 'Completed',
+      rawInput: '{"verbose":true}',
+      rawResult: 'x'.repeat(100_000),
+      callView: { card: 'generic', title: 'Router status', rawInput: 'large input' },
+      resultView: { card: 'generic', title: 'Router status', content: 'large output' },
+    })
+
+    expect(messageForWebview(tool)).toEqual({
+      id: 'tool:large',
+      role: 'tool',
+      text: 'mcp_router_status',
+      detail: 'Completed',
+      callView: { card: 'generic', title: 'Router status' },
+      resultView: { card: 'generic', title: 'Router status' },
+      deferredBody: true,
+    })
+  })
+
+  it('defers tool bodies inside resets and upserts', () => {
+    const tool = message('tool:large', 'Tool', { role: 'tool', rawResult: 'large output' })
+    const patch = messagesPatchForWebview({ reset: [tool], upserts: [tool] })
+
+    expect(patch.reset?.[0]?.deferredBody).toBe(true)
+    expect(patch.upserts?.[0]?.deferredBody).toBe(true)
   })
 })

--- a/tests/chat-state-patch.spec.ts
+++ b/tests/chat-state-patch.spec.ts
@@ -1,12 +1,28 @@
 import { describe, expect, it } from 'vitest'
 import { diffConversationMessages, messageForWebview, messagesPatchForWebview } from '../src/chat-state-patch.js'
-import type { ConversationMessage } from '../src/conversation.js'
+import { ConversationProjector, type ConversationMessage, type DshEvent } from '../src/conversation.js'
 
 function message(id: string, text: string, extra: Partial<ConversationMessage> = {}): ConversationMessage {
   return { id, role: 'assistant', text, ...extra }
 }
 
 describe('diffConversationMessages', () => {
+  it('uses projector deltas across batched chunks', () => {
+    const projector = new ConversationProjector()
+    const chunk = (seq: number, text: string): DshEvent => ({
+      type: 'assistant/chunk', seq, time: seq,
+      data: { turn: 1, step: 1, chunk: { type: 'text-delta', text } },
+    })
+    projector.apply(chunk(1, 'A'.repeat(50_000)))
+    const previous = projector.messages()
+    projector.apply(chunk(2, 'second'))
+    projector.apply(chunk(3, ' third'))
+
+    expect(diffConversationMessages(previous, projector.messages())).toEqual({
+      appends: [{ id: 'assistant:1:1', text: 'second third', streaming: true }],
+    })
+  })
+
   it('sends only the streaming message that changed', () => {
     const previous = [message('tool:1', 'Tool', { role: 'tool', rawResult: 'large output' }), message('assistant:1', 'Hel', { streaming: true })]
     const next = [message('tool:1', 'Tool', { role: 'tool', rawResult: 'large output' }), message('assistant:1', 'Hello', { streaming: true })]
@@ -72,6 +88,8 @@ describe('diffConversationMessages', () => {
       callView: { card: 'generic', title: 'Router status' },
       resultView: { card: 'generic', title: 'Router status' },
       deferredBody: true,
+      deferredBodyRevision: 'settled:17:16:100000:',
+      bodyLength: 100_000,
     })
   })
 
@@ -81,5 +99,26 @@ describe('diffConversationMessages', () => {
 
     expect(patch.reset?.[0]?.deferredBody).toBe(true)
     expect(patch.upserts?.[0]?.deferredBody).toBe(true)
+  })
+
+  it('defers streaming tools, large commands, and completed long responses', () => {
+    expect(messageForWebview(message('tool:running', 'Write', {
+      role: 'tool', streaming: true, rawInput: 'x'.repeat(50_000), callView: { card: 'diff', title: 'Write' },
+    })).deferredBody).toBe(true)
+
+    expect(messageForWebview(message('command:1', '/compact', {
+      role: 'command', rawResult: 'x'.repeat(50_000),
+    })).deferredBody).toBe(true)
+
+    const assistant = messageForWebview(message('assistant:large', 'x'.repeat(50_000)))
+    expect(assistant).toMatchObject({ role: 'assistant', text: '', deferredBody: true, bodyLength: 50_000 })
+  })
+
+  it('changes the deferred revision when an image finishes hydrating', () => {
+    const base = message('tool:image', 'Image', {
+      role: 'tool', images: [{ attachmentId: 'image', mediaType: 'image/png', width: 10, height: 10 }],
+    })
+    const hydrated = messageForWebview({ ...base, images: base.images?.map(image => ({ ...image, data: 'abc' })) })
+    expect(hydrated.deferredBodyRevision).not.toBe(messageForWebview(base).deferredBodyRevision)
   })
 })

--- a/tests/chat-state-patch.spec.ts
+++ b/tests/chat-state-patch.spec.ts
@@ -11,7 +11,9 @@ describe('diffConversationMessages', () => {
     const previous = [message('tool:1', 'Tool', { role: 'tool', rawResult: 'large output' }), message('assistant:1', 'Hel', { streaming: true })]
     const next = [message('tool:1', 'Tool', { role: 'tool', rawResult: 'large output' }), message('assistant:1', 'Hello', { streaming: true })]
 
-    expect(diffConversationMessages(previous, next)).toEqual({ upserts: [next[1]] })
+    expect(diffConversationMessages(previous, next)).toEqual({
+      appends: [{ id: 'assistant:1', text: 'lo', streaming: true }],
+    })
   })
 
   it('appends new messages without resetting existing output', () => {
@@ -19,6 +21,22 @@ describe('diffConversationMessages', () => {
     const next = [...previous, message('assistant:2', 'Next', { streaming: true })]
 
     expect(diffConversationMessages(previous, next)).toEqual({ upserts: [next[1]] })
+  })
+
+  it('finishes a streaming message without resending its full text', () => {
+    const previous = [message('assistant:1', 'Complete response', { streaming: true })]
+    const next = [message('assistant:1', 'Complete response')]
+
+    expect(diffConversationMessages(previous, next)).toEqual({
+      appends: [{ id: 'assistant:1', text: '', streaming: false }],
+    })
+  })
+
+  it('falls back to an upsert when streamed text is rewritten', () => {
+    const previous = [message('assistant:1', 'Original', { streaming: true })]
+    const next = [message('assistant:1', 'Replacement', { streaming: true })]
+
+    expect(diffConversationMessages(previous, next)).toEqual({ upserts: next })
   })
 
   it('treats equivalent image projections as unchanged', () => {

--- a/tests/tool-output-page.spec.ts
+++ b/tests/tool-output-page.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { ConversationMessage } from '../src/conversation.js'
-import { pageToolOutput, TOOL_OUTPUT_CHAR_LIMIT, TOOL_OUTPUT_ITEM_LIMIT } from '../src/tool-output-page.js'
+import { pageConversationMessage, pageToolOutput, TOOL_OUTPUT_CHAR_LIMIT, TOOL_OUTPUT_ITEM_LIMIT } from '../src/tool-output-page.js'
 
 function tool(extra: Partial<ConversationMessage>): ConversationMessage {
   return { id: 'tool:1', role: 'tool', text: 'Tool', detail: 'Completed', ...extra }
@@ -17,6 +17,12 @@ describe('tool output pages', () => {
     const second = pageToolOutput(tool({ resultView: { card: 'terminal', output } }), first.nextCursor)
     expect((second.message.resultView as { output: string }).output).toBe('x'.repeat(37))
     expect(second.nextCursor).toBeUndefined()
+  })
+
+  it('shows terminal completion metadata only on the final page', () => {
+    const message = tool({ resultView: { card: 'terminal', output: 'x'.repeat(TOOL_OUTPUT_CHAR_LIMIT + 1), exitCode: 0 } })
+    expect((pageToolOutput(message).message.resultView as { exitCode?: number }).exitCode).toBeUndefined()
+    expect((pageToolOutput(message, pageToolOutput(message).nextCursor).message.resultView as { exitCode?: number }).exitCode).toBe(0)
   })
 
   it('pages a single large diff field without transferring the other fields', () => {
@@ -83,5 +89,36 @@ describe('tool output pages', () => {
     const firstImage = pageToolOutput(message, text.nextCursor)
     expect(firstImage.message.images?.map(image => image.attachmentId)).toEqual(['one'])
     expect(firstImage.nextCursor).toBeDefined()
+  })
+
+  it('pages long assistant and command bodies without changing their roles', () => {
+    const assistant: ConversationMessage = { id: 'assistant:1', role: 'assistant', text: 'a'.repeat(TOOL_OUTPUT_CHAR_LIMIT + 3) }
+    const assistantPage = pageConversationMessage(assistant)
+    expect(assistantPage.message).toMatchObject({ role: 'assistant', resultView: { card: 'assistant-page', plainText: true } })
+    expect(assistantPage.message.text).toHaveLength(TOOL_OUTPUT_CHAR_LIMIT)
+
+    const command: ConversationMessage = { id: 'command:1', role: 'command', text: '/compact', rawResult: 'c'.repeat(TOOL_OUTPUT_CHAR_LIMIT + 2) }
+    const commandPage = pageConversationMessage(command)
+    expect(commandPage.message.role).toBe('command')
+    expect(((commandPage.message.resultView as { content: Array<{ text: string }> }).content[0]?.text)).toHaveLength(TOOL_OUTPUT_CHAR_LIMIT)
+  })
+
+  it('keeps generic locations in bounded pages after raw output', () => {
+    const locations = Array.from({ length: TOOL_OUTPUT_ITEM_LIMIT + 2 }, (_, index) => ({ path: `src/${index}.ts`, line: index + 1 }))
+    const message = tool({ rawResult: 'done', callView: { card: 'generic', locations } })
+    const text = pageConversationMessage(message)
+    const firstLocations = pageConversationMessage(message, text.nextCursor)
+    expect(((firstLocations.message.callView as { locations: unknown[] }).locations)).toHaveLength(TOOL_OUTPUT_ITEM_LIMIT)
+    expect(firstLocations.nextCursor).toBeDefined()
+  })
+
+  it('marks split web answers as plain text so Markdown is not parsed across arbitrary boundaries', () => {
+    const page = pageConversationMessage(tool({ resultView: { card: 'web', answer: '```ts\n' + 'x'.repeat(TOOL_OUTPUT_CHAR_LIMIT) } }))
+    expect(page.message.resultView).toMatchObject({ card: 'web', plainText: true })
+  })
+
+  it('returns an image directly when a tool has no textual body', () => {
+    const page = pageConversationMessage(tool({ images: [{ attachmentId: 'only', mediaType: 'image/png', width: 1, height: 1, data: 'abc' }] }))
+    expect(page.message.images?.[0]?.attachmentId).toBe('only')
   })
 })

--- a/tests/tool-output-page.spec.ts
+++ b/tests/tool-output-page.spec.ts
@@ -34,7 +34,10 @@ describe('tool output pages', () => {
     expect(firstDiff?.newText).toBeUndefined()
 
     const second = pageToolOutput(message, first.nextCursor)
-    expect((second.message.resultView as { diffs: Array<Record<string, string>> }).diffs[0]?.oldText).toBe('a')
+    const secondDiff = (second.message.resultView as { diffs: Array<Record<string, string | boolean>> }).diffs[0]
+    expect(secondDiff?.oldText).toBe('a')
+    expect(secondDiff?.continuation).toBe(true)
+    expect(firstDiff.oldText + secondDiff?.oldText).toBe(oldText)
     expect(second.nextCursor).toBeDefined()
   })
 

--- a/tests/tool-output-page.spec.ts
+++ b/tests/tool-output-page.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import type { ConversationMessage } from '../src/conversation.js'
+import { pageToolOutput, TOOL_OUTPUT_CHAR_LIMIT, TOOL_OUTPUT_ITEM_LIMIT } from '../src/tool-output-page.js'
+
+function tool(extra: Partial<ConversationMessage>): ConversationMessage {
+  return { id: 'tool:1', role: 'tool', text: 'Tool', detail: 'Completed', ...extra }
+}
+
+describe('tool output pages', () => {
+  it('bounds terminal output and resumes from an opaque cursor', () => {
+    const output = 'x'.repeat(TOOL_OUTPUT_CHAR_LIMIT + 37)
+    const first = pageToolOutput(tool({ resultView: { card: 'terminal', output } }))
+    const firstView = first.message.resultView as { output: string }
+    expect(firstView.output).toHaveLength(TOOL_OUTPUT_CHAR_LIMIT)
+    expect(first.nextCursor).toBeDefined()
+
+    const second = pageToolOutput(tool({ resultView: { card: 'terminal', output } }), first.nextCursor)
+    expect((second.message.resultView as { output: string }).output).toBe('x'.repeat(37))
+    expect(second.nextCursor).toBeUndefined()
+  })
+
+  it('pages a single large diff field without transferring the other fields', () => {
+    const oldText = 'a'.repeat(TOOL_OUTPUT_CHAR_LIMIT + 1)
+    const message = tool({ resultView: { card: 'diff', diffs: [{ path: 'large.ts', oldText, newText: 'next' }] } })
+    const first = pageToolOutput(message)
+    const firstDiff = (first.message.resultView as { diffs: Array<Record<string, string>> }).diffs[0]
+    expect(firstDiff?.oldText).toHaveLength(TOOL_OUTPUT_CHAR_LIMIT)
+    expect(firstDiff?.newText).toBeUndefined()
+
+    const second = pageToolOutput(message, first.nextCursor)
+    expect((second.message.resultView as { diffs: Array<Record<string, string>> }).diffs[0]?.oldText).toBe('a')
+    expect(second.nextCursor).toBeDefined()
+  })
+
+  it('limits read and search result collections before serialization', () => {
+    const lines = Array.from({ length: TOOL_OUTPUT_ITEM_LIMIT * 3 }, (_, index) => ({ number: index + 1, text: `line ${index + 1}` }))
+    const read = pageToolOutput(tool({ resultView: { card: 'read', path: 'large.ts', lines } }))
+    expect((read.message.resultView as { lines: unknown[] }).lines).toHaveLength(TOOL_OUTPUT_ITEM_LIMIT * 2)
+    expect(read.nextCursor).toBeDefined()
+
+    const paths = Array.from({ length: TOOL_OUTPUT_ITEM_LIMIT + 3 }, (_, index) => `file-${index}.ts`)
+    const search = pageToolOutput(tool({ resultView: { card: 'search', shape: 'paths', paths } }))
+    expect((search.message.resultView as { paths: unknown[] }).paths).toHaveLength(TOOL_OUTPUT_ITEM_LIMIT)
+    expect(search.nextCursor).toBeDefined()
+  })
+
+  it('splits an individual oversized read line across pages', () => {
+    const text = 'z'.repeat(TOOL_OUTPUT_CHAR_LIMIT + 9)
+    const message = tool({ resultView: { card: 'read', path: 'one-line.ts', lines: [{ number: 1, text }] } })
+    const first = pageToolOutput(message)
+    expect(((first.message.resultView as { lines: Array<{ text: string }> }).lines[0]?.text)).toHaveLength(TOOL_OUTPUT_CHAR_LIMIT)
+
+    const second = pageToolOutput(message, first.nextCursor)
+    expect((second.message.resultView as { lines: Array<{ text: string }> }).lines[0]?.text).toBe('z'.repeat(9))
+    expect(second.nextCursor).toBeUndefined()
+  })
+
+  it('moves from a web answer to bounded source pages', () => {
+    const sources = Array.from({ length: TOOL_OUTPUT_ITEM_LIMIT + 1 }, (_, index) => ({ title: `Source ${index}`, url: `https://example.com/${index}` }))
+    const message = tool({ resultView: { card: 'web', answer: 'Answer', sources } })
+    const answer = pageToolOutput(message)
+    expect((answer.message.resultView as { answer: string }).answer).toBe('Answer')
+
+    const sourcePage = pageToolOutput(message, answer.nextCursor)
+    expect((sourcePage.message.resultView as { sources: unknown[] }).sources).toHaveLength(TOOL_OUTPUT_ITEM_LIMIT)
+    expect(sourcePage.nextCursor).toBeDefined()
+  })
+
+  it('treats an invalid cursor as the first page', () => {
+    const message = tool({ rawResult: 'result' })
+    expect(pageToolOutput(message, 'not-json').message).toEqual(pageToolOutput(message).message)
+  })
+
+  it('loads tool-result images one at a time after text pages', () => {
+    const message = tool({
+      rawResult: 'done',
+      images: [
+        { attachmentId: 'one', mediaType: 'image/png', width: 10, height: 10, data: 'abc' },
+        { attachmentId: 'two', mediaType: 'image/png', width: 10, height: 10, data: 'def' },
+      ],
+    })
+    const text = pageToolOutput(message)
+    const firstImage = pageToolOutput(message, text.nextCursor)
+    expect(firstImage.message.images?.map(image => image.attachmentId)).toEqual(['one'])
+    expect(firstImage.nextCursor).toBeDefined()
+  })
+})

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -22,5 +22,6 @@ describe('chat webview', () => {
     expect(script).not.toContain('renderedMessages.delete(event.data.messageId)')
     expect(script).not.toContain('value.startsWith(stream.text)')
     expect(script).toContain("pendingMessageAppends.set(append.id")
+    expect(script).toContain("target.textContent += continuation.textContent")
   })
 })

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -12,4 +12,15 @@ describe('chat webview', () => {
     expect(script).toBeDefined()
     expect(() => new Function(script ?? '')).not.toThrow()
   })
+
+  it('uses append-only output and streaming paths', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const script = /<script nonce="[^"]+">([\s\S]*?)<\/script>/.exec(chatHtml(webview, mark))?.[1] ?? ''
+
+    expect(script).toContain('controller.append(event.data.page.message')
+    expect(script).not.toContain('renderedMessages.delete(event.data.messageId)')
+    expect(script).not.toContain('value.startsWith(stream.text)')
+    expect(script).toContain("pendingMessageAppends.set(append.id")
+  })
 })

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import type * as vscode from 'vscode'
+import { chatHtml } from '../src/webview.js'
+
+describe('chat webview', () => {
+  it('emits valid browser JavaScript', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const html = chatHtml(webview, mark)
+    const script = /<script nonce="[^"]+">([\s\S]*?)<\/script>/.exec(html)?.[1]
+
+    expect(script).toBeDefined()
+    expect(() => new Function(script ?? '')).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- batch streaming state updates and send only changed messages to the Webview
- preserve keyed message DOM and render updates at most once per animation frame
- lazy-load completed tool bodies and reveal long text output in bounded chunks
- add regression coverage for message patching, deferred tool payloads, and Webview script validity

Fixes #7

## Verification

- corepack pnpm check — 20 test files, 89 tests passed
- corepack pnpm run package
- confirmed dist/chat-state-patch.js is included in the generated VSIX

All three implementation commits credit @haode01 as co-author.