### PR TITLE
fix: route unresolved Windows dsh.cmd through cmd.exe (closes #9)

### DIFF
--- a/src/launch.ts
+++ b/src/launch.ts
@@ -37,6 +37,37 @@ function executableBasename(executable: string): string {
   return executable.split(/[\\/]/).at(-1) ?? executable
 }
 
+/** Node's spawn cannot execute .cmd/.bat shims directly on modern Windows. */
+function isWindowsShellScript(executable: string): boolean {
+  const basename = executableBasename(executable).toLowerCase()
+  return basename.endsWith('.cmd') || basename.endsWith('.bat')
+}
+
+function comSpec(env: Readonly<Record<string, string | undefined>>): string {
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toLowerCase() === 'comspec' && value !== undefined && value !== '') return value
+  }
+  return 'cmd.exe'
+}
+
+/**
+ * Run a Windows .cmd/.bat shim through the command interpreter. cmd.exe /c
+ * launches the shim without spawn's direct-.cmd EINVAL and without shell:true's
+ * unescaped-argument hazard (DEP0190). Used as a last resort when the npm JS
+ * entry cannot be resolved (e.g. pnpm/yarn/volta global install layouts).
+ */
+function windowsShellFallback(
+  command: string,
+  args: readonly string[],
+  env: Readonly<Record<string, string | undefined>>,
+): LaunchCommand {
+  return {
+    command: comSpec(env),
+    args: ['/c', command, ...args],
+    sourceCheckout: false,
+  }
+}
+
 function explicitExecutablePath(executable: string, cwd: string): string {
   if (isAbsolute(executable)) return executable
   return resolve(cwd, ...executable.split(/[\\/]+/))
@@ -192,10 +223,14 @@ export function resolveLaunch(
   }
 
   if (configuredExecutable !== '') {
-    const windowsLaunch = host.platform === 'win32'
-      ? resolveWindowsDsh(configuredExecutable, configuredArgs, host)
-      : undefined
-    return windowsLaunch ?? {
+    if (host.platform === 'win32') {
+      const windowsLaunch = resolveWindowsDsh(configuredExecutable, configuredArgs, host)
+      if (windowsLaunch !== undefined) return windowsLaunch
+      if (isWindowsShellScript(configuredExecutable)) {
+        return windowsShellFallback(configuredExecutable, configuredArgs, host.env)
+      }
+    }
+    return {
       command: configuredExecutable,
       args: [...configuredArgs],
       sourceCheckout: false,
@@ -226,10 +261,11 @@ export function resolveLaunch(
   if (host.platform === 'win32') {
     const windowsLaunch = resolveWindowsDsh('', configuredArgs, host)
     if (windowsLaunch !== undefined) return windowsLaunch
+    return windowsShellFallback('dsh.cmd', configuredArgs, host.env)
   }
 
   return {
-    command: host.platform === 'win32' ? 'dsh.cmd' : 'dsh',
+    command: 'dsh',
     args: [...configuredArgs],
     sourceCheckout: false,
   }

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -227,7 +227,13 @@ export function resolveLaunch(
       const windowsLaunch = resolveWindowsDsh(configuredExecutable, configuredArgs, host)
       if (windowsLaunch !== undefined) return windowsLaunch
       if (isWindowsShellScript(configuredExecutable)) {
-        return windowsShellFallback(configuredExecutable, configuredArgs, host.env)
+        // Settings JSON favors forward slashes, which cmd.exe mis-parses in an
+        // unquoted command token. resolve() also pins relative paths to the
+        // extension cwd instead of whatever directory cmd starts in.
+        const command = /[\\/]/.test(configuredExecutable)
+          ? explicitExecutablePath(configuredExecutable, host.cwd)
+          : configuredExecutable
+        return windowsShellFallback(command, configuredArgs, host.env)
       }
     }
     return {
@@ -261,7 +267,9 @@ export function resolveLaunch(
   if (host.platform === 'win32') {
     const windowsLaunch = resolveWindowsDsh('', configuredArgs, host)
     if (windowsLaunch !== undefined) return windowsLaunch
-    return windowsShellFallback('dsh.cmd', configuredArgs, host.env)
+    // Extensionless so cmd.exe applies PATHEXT: finds npm/pnpm/yarn dsh.cmd
+    // and also volta/scoop dsh.exe shims, which have no .cmd sibling.
+    return windowsShellFallback('dsh', configuredArgs, host.env)
   }
 
   return {

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -113,14 +113,15 @@ describe('DSH launch resolution', () => {
     })
   })
 
-  it('routes the dsh.cmd fallback through cmd.exe when a Windows install cannot be resolved', () => {
+  it('routes the PATH fallback through cmd.exe when a Windows install cannot be resolved', () => {
     const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-missing-'))
     expect(resolveLaunch('/not/a/source/tree', '', ['web'], {
       platform: 'win32',
       env: { Path: prefix, ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
     })).toEqual({
       command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/c', 'dsh.cmd', 'web'],
+      // Extensionless: PATHEXT resolution covers dsh.cmd and volta/scoop dsh.exe.
+      args: ['/c', 'dsh', 'web'],
       sourceCheckout: false,
     })
   })
@@ -132,7 +133,20 @@ describe('DSH launch resolution', () => {
       env: { Path: prefix },
     })).toEqual({
       command: 'cmd.exe',
-      args: ['/c', 'dsh.cmd', 'web'],
+      args: ['/c', 'dsh', 'web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('resolves a relative explicit dsh.cmd against the workspace before invoking cmd.exe', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-relative-'))
+    expect(resolveLaunch('/not/a/source/tree', 'tools/dsh.cmd', ['web'], {
+      platform: 'win32',
+      cwd: prefix,
+      env: { ComSpec: 'cmd.exe' },
+    })).toEqual({
+      command: 'cmd.exe',
+      args: ['/c', join(prefix, 'tools', 'dsh.cmd'), 'web'],
       sourceCheckout: false,
     })
   })

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -113,14 +113,40 @@ describe('DSH launch resolution', () => {
     })
   })
 
-  it('keeps the dsh.cmd fallback when a Windows install cannot be resolved safely', () => {
+  it('routes the dsh.cmd fallback through cmd.exe when a Windows install cannot be resolved', () => {
     const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-missing-'))
+    expect(resolveLaunch('/not/a/source/tree', '', ['web'], {
+      platform: 'win32',
+      env: { Path: prefix, ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    })).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/c', 'dsh.cmd', 'web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('defaults to cmd.exe when ComSpec is unset for the Windows fallback', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-nocomspec-'))
     expect(resolveLaunch('/not/a/source/tree', '', ['web'], {
       platform: 'win32',
       env: { Path: prefix },
     })).toEqual({
-      command: 'dsh.cmd',
-      args: ['web'],
+      command: 'cmd.exe',
+      args: ['/c', 'dsh.cmd', 'web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('routes an unresolvable explicit dsh.cmd through cmd.exe on Windows', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-explicit-missing-'))
+    const cmdPath = join(prefix, 'dsh.cmd')
+    writeFileSync(cmdPath, '@echo off\r\n')
+    expect(resolveLaunch('/not/a/source/tree', cmdPath, ['web'], {
+      platform: 'win32',
+      env: { ComSpec: 'cmd.exe' },
+    })).toEqual({
+      command: 'cmd.exe',
+      args: ['/c', cmdPath, 'web'],
       sourceCheckout: false,
     })
   })


### PR DESCRIPTION
## Problem

Issue #9 (`spawn EINVAL`, dup of #2) surfaces on Windows even after the PR #3 Windows fix, because that fix only handles npm's global layout. When the DSH JS entry can't be resolved — pnpm / yarn / volta / scoop global installs, where `dsh.cmd` has no sibling `node_modules/@deepseek-ai/dsh` — `resolveLaunch` fell back to a bare `dsh.cmd` command. Spawning a `.cmd` shim without a shell throws `EINVAL` on modern Node (18.20+), so the sidebar still crashes on start for those users.

## Fix

Route the unresolvable Windows fallback through the command interpreter instead of spawning the shim directly:

- New `windowsShellFallback()` returns `command: cmd.exe, args: ['/c', <shim>, ...]` (honors `ComSpec`, defaults to `cmd.exe`).
- Applied to **both** fallback paths: PATH-discovery fallback and an explicitly configured `.cmd`/`.bat` executable.
- `cmd.exe /c` launches the shim **without** the direct-`.cmd` `EINVAL` and **without** `shell: true`'s unescaped-argument hazard (DEP0190) — consistent with the design choice in PR #3.

The successful npm-layout resolution path (resolve JS entry → run via node) is unchanged.

## Tests

- Replaced the old assertion that preserved the (broken) bare `dsh.cmd` fallback.
- Added: cmd.exe routing with explicit `ComSpec`, default `cmd.exe` when `ComSpec` unset, and an unresolvable explicit `dsh.cmd` path.
- `pnpm check` green: typecheck + 109 tests + build.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)