### PR TITLE
fix: address pre-release review findings (webview state sync, runtime, launch)

### DIFF
--- a/src/chat-state-patch.ts
+++ b/src/chat-state-patch.ts
@@ -37,9 +37,11 @@ export function messageForWebview(message: ConversationMessage): ConversationMes
     || message.rawResult !== undefined
     || (message.images?.length ?? 0) > 0)
   const hasLargeCommandBody = message.role === 'command' && (message.rawResult?.length ?? 0) > WEBVIEW_INLINE_CHAR_LIMIT
+  // Only text length defers an assistant body: deferring on hydrated images
+  // alone would blank an already-visible short answer behind a load button.
   const hasLargeAssistantBody = message.role === 'assistant'
     && message.streaming !== true
-    && (message.text.length > WEBVIEW_INLINE_CHAR_LIMIT || (message.images?.some(image => image.data !== undefined) ?? false))
+    && message.text.length > WEBVIEW_INLINE_CHAR_LIMIT
   if (!hasToolBody && !hasLargeCommandBody && !hasLargeAssistantBody) return message
   const callView = compactToolView(message.callView)
   const resultView = compactToolView(message.resultView)
@@ -47,6 +49,7 @@ export function messageForWebview(message: ConversationMessage): ConversationMes
     id: message.id,
     role: message.role,
     text: hasLargeAssistantBody ? '' : message.text,
+    ...(message.streaming === undefined ? {} : { streaming: message.streaming }),
     ...(message.detail === undefined ? {} : { detail: message.detail }),
     ...(message.failed === undefined ? {} : { failed: message.failed }),
     ...(callView === undefined ? {} : { callView }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -400,7 +400,7 @@ class DshChatController implements vscode.Disposable {
       const execution = await this.requireClient().executeCommand(
         this._state.sessionId,
         normalized,
-        usesRc8Envelope ? images : undefined,
+        usesRc8Envelope && images.length > 0 ? images : undefined,
       )
       if (execution === undefined) throw new Error(`DeepSeek did not recognize ${slash.token}.`)
       if (images.length > 0 && execution.result.kind === 'error') {
@@ -1070,8 +1070,8 @@ class DshSurface implements vscode.Disposable {
   }
 
   private async postFullState(state: ChatViewState): Promise<void> {
-    await this.webview.postMessage({ type: 'state', state: stateForWebview(state) })
-    this.postedState = state
+    const delivered = await this.webview.postMessage({ type: 'state', state: stateForWebview(state) })
+    this.postedState = delivered ? state : undefined
   }
 
   private async postStateUpdate(state: ChatViewState): Promise<void> {
@@ -1081,7 +1081,14 @@ class DshSurface implements vscode.Disposable {
       return
     }
     const update = stateUpdate(previous, state)
-    if (update !== undefined) await this.webview.postMessage({ type: 'state-update', update: stateUpdateForWebview(update) })
+    if (update !== undefined) {
+      const delivered = await this.webview.postMessage({ type: 'state-update', update: stateUpdateForWebview(update) })
+      if (!delivered) {
+        // A dropped patch would desync every later diff; resend the full state next time.
+        this.postedState = undefined
+        return
+      }
+    }
     this.postedState = state
   }
 
@@ -1198,7 +1205,9 @@ class DshSurface implements vscode.Disposable {
               : undefined
             await this.webview.postMessage({
               type: 'tool-output',
-              sessionId,
+              // Address the reply to the requesting session so its webview does
+              // not drop a session-mismatch error and hang on the 15s timeout.
+              sessionId: requestedSessionId,
               messageId: value.messageId,
               requestId: value.requestId,
               ...(message === undefined

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -148,7 +148,8 @@ function resolveWindowsDsh(
 }
 
 function supportsNoOpen(version: string): boolean {
-  const match = /(?:^|\s)(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?(?:\s|$)/.exec(version)
+  // Tolerate a 'v' prefix and semver build metadata (e.g. 'v0.1.0-rc.8+abc').
+  const match = /(?:^|\s)v?(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?(?=[+\s]|$)/.exec(version)
   if (match === null) return false
   const major = Number(match[1])
   const minor = Number(match[2])

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import * as vscode from 'vscode'
 import { DEEPSEEK_API_KEY_SECRET } from './credentials.js'
-import { parseDshWebUrl, resolveLaunch, type LaunchCommand, webArgsForDshVersion } from './launch.js'
+import { findSourceRoot, parseDshWebUrl, resolveLaunch, type LaunchCommand, webArgsForDshVersion } from './launch.js'
 import {
   DEFAULT_DSH_SERVER_URL,
   DEFAULT_DSH_WEB_ARGS,
@@ -61,7 +61,9 @@ function readDshVersion(launch: LaunchCommand, cwd: string): Promise<string | un
     child.stdout.on('data', (chunk: string) => { output += chunk })
     child.stderr.on('data', (chunk: string) => { output += chunk })
     child.on('error', () => { finish() })
-    child.on('exit', code => { finish(code === 0 ? output.trim() : undefined) })
+    // 'close' (not 'exit') guarantees the stdio streams have flushed, so the
+    // version string cannot be truncated by a late stdout chunk.
+    child.on('close', code => { finish(code === 0 ? output.trim() : undefined) })
     timer = setTimeout(() => {
       child.kill()
       finish()
@@ -127,7 +129,10 @@ export class DshRuntime implements vscode.Disposable {
     let version: string | undefined
     let storedApiKey: string | undefined
     try {
-      if (shouldProbeExistingDsh(reuseExistingRuntime, configuredExecutable, hasCustomArguments)) {
+      // A nested deepseek-harness checkout is the documented empty-executable
+      // launch; an unrelated stock DSH on 3080 must not silently pre-empt it.
+      if (shouldProbeExistingDsh(reuseExistingRuntime, configuredExecutable, hasCustomArguments)
+        && findSourceRoot(this.context.extensionUri.fsPath) === undefined) {
         const existingUrl = new URL(DEFAULT_DSH_SERVER_URL)
         this.publish({ kind: 'starting', detail: 'Looking for an existing DeepSeek Harness runtime…' })
         if (await probeDshServer(existingUrl)) {

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -780,8 +780,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         rendered.markdown.root.classList.toggle('streaming', message.streaming === true);
         return rendered.node;
       }
-      const next = renderMessage(message);
       if (rendered) deferredOutputViews.delete(message.id);
+      pendingMessageAppends.delete(message.id);
+      const next = renderMessage(message);
       if (rendered && rendered.node.isConnected) rendered.node.replaceWith(next.node);
       renderedMessages.set(message.id, next);
       return next.node;

--- a/tests/chat-state-patch.spec.ts
+++ b/tests/chat-state-patch.spec.ts
@@ -114,6 +114,21 @@ describe('diffConversationMessages', () => {
     expect(assistant).toMatchObject({ role: 'assistant', text: '', deferredBody: true, bodyLength: 50_000 })
   })
 
+  it('keeps the streaming flag on a deferred running tool', () => {
+    const tool = messageForWebview(message('tool:running', 'Write', {
+      role: 'tool', streaming: true, detail: 'Running…', callView: { card: 'diff', title: 'Write' },
+    }))
+    expect(tool.deferredBody).toBe(true)
+    expect(tool.streaming).toBe(true)
+  })
+
+  it('keeps a short assistant answer with hydrated images inline', () => {
+    const answer = message('assistant:1', 'Here it is.', {
+      images: [{ attachmentId: 'image', mediaType: 'image/png', width: 10, height: 10, data: 'abc' }],
+    })
+    expect(messageForWebview(answer)).toBe(answer)
+  })
+
   it('changes the deferred revision when an image finishes hydrating', () => {
     const base = message('tool:image', 'Image', {
       role: 'tool', images: [{ attachmentId: 'image', mediaType: 'image/png', width: 10, height: 10 }],

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -20,6 +20,9 @@ describe('DSH launch resolution', () => {
     expect(webArgsForDshVersion([...args, '--no-open'], '0.1.0-rc.8')).toEqual([...args, '--no-open'])
     expect(webArgsForDshVersion(['--profile', 'web', '--port', '0'], 'dsh 0.1.0-rc.8'))
       .toEqual(['--profile', 'web', '--port', '0', '--no-open'])
+    expect(webArgsForDshVersion(args, 'v0.1.0-rc.8')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(args, '0.1.0-rc.8+build.5')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(args, 'v0.1.0-rc.7')).toEqual(args)
   })
 
   it('finds the official source checkout and launches its real CLI entry', () => {


### PR DESCRIPTION
A deep multi-agent review of the changes since v0.0.2 surfaced ten correctness issues; this fixes nine (one candidate was refuted during verification).

## Webview / state sync
- **Running tools rendered as settled**: `messageForWebview` dropped the `streaming` flag from deferred tool copies, so in-progress tools showed the ✓ icon, collapsed. The flag is now carried over.
- **Short answers with images vanished**: a settled assistant message with any hydrated image was deferred with `text: ''`, replacing visible text with a 'Show full response' button. Only text length defers an assistant body now.
- **Orphaned 'Loading output…'**: `messageNode` deleted the deferred-output controller *after* `renderMessage` had just re-registered it, so re-rendered deferred bodies never received their loaded pages. The stale controller is now removed before re-rendering.
- **Duplicated streamed text**: the full-render path never cleared `pendingMessageAppends`, so an already-painted delta could be replayed by the next append. It is cleared on full render.
- **Permanent desync after a dropped post**: `postStateUpdate` advanced `postedState` even when `webview.postMessage` resolved `false`; every later diff was then computed against a state the webview never saw. Non-delivery now forces a full-state resend.

## Protocol / runtime / launch
- `commands/execute` no longer includes `images: []` on commands run without attachments.
- The `load-tool-output` reply is addressed to the requesting sessionId, so a session-mismatch error reaches the webview instead of dying to the 15s timeout.
- `dsh --version` is read on `'close'` instead of `'exit'`, so a late stdout flush cannot truncate the version and silently disable `--no-open`.
- The `--no-open` version check accepts `v` prefixes and semver build metadata.
- A nested deepseek-harness source checkout now takes precedence over the port-3080 runtime-reuse probe, matching the documented empty-executable behavior.

`pnpm check` green: typecheck + 112 tests + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)