### PR TITLE
feat: check image attachments against the runtime's published limits

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,12 @@ import {
   type SkillDescriptor,
 } from './dsh-client.js'
 import { replaceTextPreservingIdeContext, withIdeContext, type IdeContextReference, type IdeContextSnapshot } from './ide-context.js'
+import {
+  imageLimitsOf,
+  rejectImageAttachments,
+  type ImageAttachmentLimits,
+  type ImageCandidate,
+} from './image-limits.js'
 import { jobsSnapshotOf, type JobItem } from './jobs.js'
 import { queueSnapshotOf, type QueueItemState } from './queue.js'
 import { DshRuntime, type RuntimeOwnership, type RuntimeState } from './runtime.js'
@@ -132,6 +138,7 @@ interface ChatViewState {
   skills: SkillDescriptor[]
   agentPreset: AgentPresetState
   usage: UsageMeterState
+  imageLimits: ImageAttachmentLimits | undefined
   permissions: PermissionPresetItem[]
   plan: PlanModeState
   changedFiles: ChangedFileGroup[]
@@ -189,6 +196,7 @@ function initialState(cwd: string): ChatViewState {
     skills: [],
     agentPreset: unavailableAgentPresetState(),
     usage: unavailableUsageMeterState(),
+    imageLimits: undefined,
     permissions: [],
     plan: planModeStateOf(undefined),
     changedFiles: [],
@@ -601,6 +609,7 @@ class DshChatController implements vscode.Disposable {
       skills: [],
       agentPreset: unavailableAgentPresetState(),
       usage: usageMeterStateOf(summary?.projections?.values),
+      imageLimits: imageLimitsOf(summary?.projections?.values?.imageLimits),
       permissions: permissionPresetsOf(summary?.projections?.values?.permissions),
       plan: planModeStateOf(summary?.projections?.values?.plan),
       changedFiles: this.diffReviews.rebuild(sessionId, this.cwd, events),
@@ -836,6 +845,9 @@ class DshChatController implements vscode.Disposable {
         this.publish({
           sessions: this._state.sessions.map(item => item.id === sessionId ? { ...item, title: payload.value as string } : item),
         })
+      }
+      if (payload.key === 'imageLimits' && sessionId === this._state.sessionId) {
+        this.publish({ imageLimits: imageLimitsOf(payload.value) })
       }
       if (payload.key === 'permissions' && sessionId === this._state.sessionId) {
         this.publish({ permissions: permissionPresetsOf(payload.value) })
@@ -1112,11 +1124,13 @@ class DshSurface implements vscode.Disposable {
       filters: { Images: ['png', 'jpg', 'jpeg', 'webp', 'gif'] },
     })
     if (selected === undefined) return
+
+    const incoming: Array<PromptImage & { id: string }> = []
     for (const uri of selected) {
       const mediaType = imageMediaType(uri.fsPath)
       if (mediaType === undefined) continue
       const bytes = await vscode.workspace.fs.readFile(uri)
-      this.draftImages.push({
+      incoming.push({
         id: randomUUID(),
         type: 'image',
         mediaType,
@@ -1124,6 +1138,20 @@ class DshSurface implements vscode.Disposable {
         name: path.basename(uri.fsPath),
       })
     }
+    if (incoming.length === 0) return
+
+    // Answer with the runtime's own bounds before a rejected prompt spends the upload.
+    const rejection = rejectImageAttachments(
+      this.draftImages.map(candidateOf),
+      incoming.map(candidateOf),
+      this.controller.state.imageLimits,
+    )
+    if (rejection !== undefined) {
+      void vscode.window.showWarningMessage(rejection)
+      return
+    }
+
+    this.draftImages.push(...incoming)
     await this.publishDraftImages()
   }
 
@@ -1374,6 +1402,21 @@ class DshSurface implements vscode.Disposable {
       }
     }
     void run().catch(error => { this.controller.report(error) })
+  }
+}
+
+/** Decoded byte count of a base64 payload, without materializing the bytes again. */
+function base64Bytes(data: string): number {
+  const padding = data.endsWith('==') ? 2 : data.endsWith('=') ? 1 : 0
+  return Math.max(0, Math.floor(data.length / 4) * 3 - padding)
+}
+
+/** Measure a draft attachment against the runtime's published upload bounds. */
+function candidateOf(image: PromptImage & { id: string }): ImageCandidate {
+  return {
+    mediaType: image.mediaType,
+    bytes: base64Bytes(image.data),
+    ...(image.name === undefined ? {} : { name: image.name }),
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1261,6 +1261,18 @@ class DshSurface implements vscode.Disposable {
             const carriesIdeContext = slash.kind === 'prompt'
             const ideContext = carriesIdeContext ? await this.editorContext.snapshotForPrompt(value.text) : undefined
             const mode: PromptMode = value.mode === 'steer' ? 'steer' : 'queue'
+            // Limits can land after the picker ran, so the send is the last point
+            // where the whole draft can be measured against what the runtime states.
+            const rejection = rejectImageAttachments(
+              [],
+              this.draftImages.map(candidateOf),
+              this.controller.state.imageLimits,
+            )
+            if (rejection !== undefined) {
+              void vscode.window.showWarningMessage(rejection)
+              this.setPrompt(value.text)
+              return
+            }
             await this.controller.send(value.text, this.draftImages, ideContext, mode)
             this.draftImages.length = 0
             if (carriesIdeContext) this.editorContext.clearPinned()

--- a/src/image-limits.ts
+++ b/src/image-limits.ts
@@ -63,7 +63,9 @@ export function imageSizeText(bytes: number): string {
  * the batch may be attached.
  *
  * An unsupported media type is deliberately not rejected here: DSH answers that
- * case with its own reason, and duplicating the list would let the two drift.
+ * case with its own reason, and duplicating the list would let the two drift. The
+ * count and byte bounds still apply to such a batch — they hold whatever the types,
+ * so one unadvertised file cannot carry an over-limit payload past this check.
  */
 export function rejectImageAttachments(
   attached: readonly ImageCandidate[],
@@ -71,8 +73,6 @@ export function rejectImageAttachments(
   limits: ImageAttachmentLimits | undefined,
 ): string | undefined {
   if (limits === undefined || incoming.length === 0) return undefined
-
-  if (incoming.some(image => !limits.mediaTypes.includes(image.mediaType))) return undefined
 
   if (attached.length + incoming.length > limits.maxImagesPerMessage) {
     return `DeepSeek Harness accepts at most ${String(limits.maxImagesPerMessage)} images per message.`

--- a/src/image-limits.ts
+++ b/src/image-limits.ts
@@ -1,0 +1,93 @@
+import type { ImageMediaType } from './dsh-client.js'
+
+/** Deployment-resolved upload bounds published by the `imageLimits` session projection. */
+export interface ImageAttachmentLimits {
+  maxImageBytes: number
+  maxImagesPerMessage: number
+  maxMessageImageBytes: number
+  mediaTypes: readonly string[]
+}
+
+/** One already-attached or about-to-be-attached image, measured in decoded bytes. */
+export interface ImageCandidate {
+  mediaType: ImageMediaType
+  bytes: number
+  name?: string
+}
+
+function recordOf(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined
+}
+
+function countOf(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined
+}
+
+/**
+ * Read the limits published by DSH. Every field must be usable: a partial
+ * payload leaves intake unguarded rather than enforcing a bound the runtime
+ * never stated.
+ */
+export function imageLimitsOf(value: unknown): ImageAttachmentLimits | undefined {
+  const record = recordOf(value)
+  if (record === undefined) return undefined
+  const maxImageBytes = countOf(record.maxImageBytes)
+  const maxImagesPerMessage = countOf(record.maxImagesPerMessage)
+  const maxMessageImageBytes = countOf(record.maxMessageImageBytes)
+  const mediaTypes = Array.isArray(record.mediaTypes)
+    ? record.mediaTypes.filter((entry): entry is string => typeof entry === 'string')
+    : undefined
+  if (maxImageBytes === undefined
+    || maxImagesPerMessage === undefined
+    || maxMessageImageBytes === undefined
+    || mediaTypes === undefined
+    || mediaTypes.length === 0) {
+    return undefined
+  }
+  return { maxImageBytes, maxImagesPerMessage, maxMessageImageBytes, mediaTypes }
+}
+
+/** Render a byte bound for a message the user reads, never rounding a real bound to `0`. */
+export function imageSizeText(bytes: number): string {
+  const mib = bytes / (1024 * 1024)
+  if (mib < 1) return `${String(Math.max(1, Math.round(bytes / 1024)))} KB`
+  const rounded = mib >= 10 ? Math.round(mib) : Math.round(mib * 10) / 10
+  return `${String(rounded)} MB`
+}
+
+/**
+ * Pre-flight one intake against the runtime's own bounds, mirroring the order the
+ * official DSH composer applies. Returns the message to show, or `undefined` when
+ * the batch may be attached.
+ *
+ * An unsupported media type is deliberately not rejected here: DSH answers that
+ * case with its own reason, and duplicating the list would let the two drift.
+ */
+export function rejectImageAttachments(
+  attached: readonly ImageCandidate[],
+  incoming: readonly ImageCandidate[],
+  limits: ImageAttachmentLimits | undefined,
+): string | undefined {
+  if (limits === undefined || incoming.length === 0) return undefined
+
+  if (incoming.some(image => !limits.mediaTypes.includes(image.mediaType))) return undefined
+
+  if (attached.length + incoming.length > limits.maxImagesPerMessage) {
+    return `DeepSeek Harness accepts at most ${String(limits.maxImagesPerMessage)} images per message.`
+  }
+
+  const oversized = incoming.find(image => image.bytes > limits.maxImageBytes)
+  if (oversized !== undefined) {
+    const label = oversized.name === undefined ? 'That image' : `\`${oversized.name}\``
+    return `${label} is larger than the ${imageSizeText(limits.maxImageBytes)} limit for a single image.`
+  }
+
+  const total = [...attached, ...incoming].reduce((sum, image) => sum + image.bytes, 0)
+  if (total > limits.maxMessageImageBytes) {
+    return `Those images exceed the ${imageSizeText(limits.maxMessageImageBytes)} limit for one message.`
+  }
+
+  return undefined
+}

--- a/tests/image-limits.spec.ts
+++ b/tests/image-limits.spec.ts
@@ -81,12 +81,35 @@ describe('DSH image attachment limits', () => {
     )).toBe('Those images exceed the 2 KB limit for one message.')
   })
 
-  it('defers an unsupported media type to the runtime instead of guessing', () => {
+  it('leaves an unsupported media type to the runtime but still bounds the batch', () => {
+    // Whether the type is accepted is DSH's call, so a lone unadvertised file passes.
+    expect(rejectImageAttachments([], [{ mediaType: 'image/gif', bytes: 500 }], limits))
+      .toBeUndefined()
+    // It must not carry an over-limit payload past the media-independent bounds.
+    expect(rejectImageAttachments([], [{ mediaType: 'image/gif', bytes: 1001, name: 'big.gif' }], limits))
+      .toBe('`big.gif` is larger than the 1 KB limit for a single image.')
     expect(rejectImageAttachments(
       [],
-      [{ mediaType: 'image/gif', bytes: 999999 }],
+      [
+        { mediaType: 'image/gif', bytes: 900 },
+        { mediaType: 'image/png', bytes: 900 },
+        { mediaType: 'image/png', bytes: 900 },
+      ],
       limits,
-    )).toBeUndefined()
+    )).toBe('Those images exceed the 2 KB limit for one message.')
+  })
+
+  it('measures the whole draft at send time, not just the newest batch', () => {
+    // A draft picked while the projection was still in flight is re-checked on send,
+    // where nothing counts as already attached: the draft itself is the batch.
+    const draft = [
+      { mediaType: 'image/png' as const, bytes: 900 },
+      { mediaType: 'image/png' as const, bytes: 900 },
+      { mediaType: 'image/png' as const, bytes: 900 },
+    ]
+    expect(rejectImageAttachments([], draft, undefined)).toBeUndefined()
+    expect(rejectImageAttachments([], draft, limits))
+      .toBe('Those images exceed the 2 KB limit for one message.')
   })
 
   it('attaches without complaint when the runtime published no limits', () => {

--- a/tests/image-limits.spec.ts
+++ b/tests/image-limits.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  imageLimitsOf,
+  imageSizeText,
+  rejectImageAttachments,
+  type ImageAttachmentLimits,
+} from '../src/image-limits.ts'
+
+// The exact payload the 0.1.1-rc.2 `imageLimits` projection publishes.
+const published = {
+  maxImageBytes: 20971520,
+  maxImagesPerMessage: 20,
+  maxMessageImageBytes: 209715200,
+  maxImagePixels: 64000000,
+  maxImageDimension: 8192,
+  mediaTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/gif'],
+}
+
+const limits: ImageAttachmentLimits = {
+  maxImageBytes: 1000,
+  maxImagesPerMessage: 3,
+  maxMessageImageBytes: 2000,
+  mediaTypes: ['image/png', 'image/jpeg'],
+}
+
+describe('DSH image attachment limits', () => {
+  it('reads the limits the runtime publishes', () => {
+    expect(imageLimitsOf(published)).toEqual({
+      maxImageBytes: 20971520,
+      maxImagesPerMessage: 20,
+      maxMessageImageBytes: 209715200,
+      mediaTypes: ['image/png', 'image/jpeg', 'image/webp', 'image/gif'],
+    })
+  })
+
+  it('leaves intake unguarded when the runtime states no usable bound', () => {
+    expect(imageLimitsOf(undefined)).toBeUndefined()
+    expect(imageLimitsOf(null)).toBeUndefined()
+    expect(imageLimitsOf({})).toBeUndefined()
+    expect(imageLimitsOf([published])).toBeUndefined()
+    expect(imageLimitsOf({ ...published, mediaTypes: [] })).toBeUndefined()
+    expect(imageLimitsOf({ ...published, maxImageBytes: 0 })).toBeUndefined()
+    expect(imageLimitsOf({ ...published, maxImagesPerMessage: -1 })).toBeUndefined()
+    expect(imageLimitsOf({ ...published, maxMessageImageBytes: 'lots' })).toBeUndefined()
+  })
+
+  it('accepts a batch that fits every bound', () => {
+    expect(rejectImageAttachments(
+      [{ mediaType: 'image/png', bytes: 500 }],
+      [{ mediaType: 'image/png', bytes: 500 }],
+      limits,
+    )).toBeUndefined()
+  })
+
+  it('counts images already attached toward the per-message count', () => {
+    const attached = [
+      { mediaType: 'image/png' as const, bytes: 10 },
+      { mediaType: 'image/png' as const, bytes: 10 },
+    ]
+    expect(rejectImageAttachments(attached, [{ mediaType: 'image/png', bytes: 10 }], limits))
+      .toBeUndefined()
+    expect(rejectImageAttachments(
+      attached,
+      [{ mediaType: 'image/png', bytes: 10 }, { mediaType: 'image/png', bytes: 10 }],
+      limits,
+    )).toBe('DeepSeek Harness accepts at most 3 images per message.')
+  })
+
+  it('names the offending file when one image is too large', () => {
+    expect(rejectImageAttachments([], [{ mediaType: 'image/png', bytes: 1001, name: 'big.png' }], limits))
+      .toBe('`big.png` is larger than the 1 KB limit for a single image.')
+    expect(rejectImageAttachments([], [{ mediaType: 'image/png', bytes: 1001 }], limits))
+      .toBe('That image is larger than the 1 KB limit for a single image.')
+  })
+
+  it('rejects a batch whose combined bytes exceed the message bound', () => {
+    expect(rejectImageAttachments(
+      [{ mediaType: 'image/png', bytes: 900 }],
+      [{ mediaType: 'image/png', bytes: 900 }, { mediaType: 'image/png', bytes: 900 }],
+      limits,
+    )).toBe('Those images exceed the 2 KB limit for one message.')
+  })
+
+  it('defers an unsupported media type to the runtime instead of guessing', () => {
+    expect(rejectImageAttachments(
+      [],
+      [{ mediaType: 'image/gif', bytes: 999999 }],
+      limits,
+    )).toBeUndefined()
+  })
+
+  it('attaches without complaint when the runtime published no limits', () => {
+    expect(rejectImageAttachments([], [{ mediaType: 'image/png', bytes: 999999999 }], undefined))
+      .toBeUndefined()
+    expect(rejectImageAttachments([], [], limits)).toBeUndefined()
+  })
+
+  it('renders byte bounds the way the composer does', () => {
+    expect(imageSizeText(20971520)).toBe('20 MB')
+    expect(imageSizeText(209715200)).toBe('200 MB')
+    expect(imageSizeText(1572864)).toBe('1.5 MB')
+    expect(imageSizeText(500 * 1024)).toBe('500 KB')
+    expect(imageSizeText(1)).toBe('1 KB')
+  })
+})

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -25,6 +25,15 @@ describe('DSH launch resolution', () => {
     expect(webArgsForDshVersion(args, 'v0.1.0-rc.7')).toEqual(args)
   })
 
+  it('keeps suppressing the browser handoff on the 0.1.1 release candidates and later', () => {
+    const args = ['web', '--host', '127.0.0.1', '--port', '0']
+    expect(webArgsForDshVersion(args, '0.1.1-rc.1')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(args, '0.1.1-rc.2')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(args, '0.1.1')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(args, '0.2.0-rc.1')).toEqual([...args, '--no-open'])
+    expect(webArgsForDshVersion(args, '1.0.0')).toEqual([...args, '--no-open'])
+  })
+
   it('finds the official source checkout and launches its real CLI entry', () => {
     const root = mkdtempSync(join(tmpdir(), 'dsh-vscode-source-'))
     mkdirSync(join(root, 'apps', 'cli', 'src'), { recursive: true })


### PR DESCRIPTION
## What

Attaching an image did no local validation: an over-limit batch was read from disk, base64-encoded, and only refused once DSH answered the prompt.

This reads the `imageLimits` session projection into chat state and pre-flights one intake against it, in the same order the official DSH composer applies (`client-ui-conversation`'s `intakeImages`): per-message count → per-image bytes → combined bytes.

## Verification

Driven against a live `@deepseek-ai/dsh@0.1.1-rc.2` runtime, using the limits it actually publishes:

```
parsed limits : maxImageBytes=20MiB, maxImagesPerMessage=20, maxMessageImageBytes=200MiB
21 images     : DeepSeek Harness accepts at most 20 images per message.
1x 21MiB      : `x.png` is larger than the 20 MB limit for a single image.
11x 20MiB     : Those images exceed the 200 MB limit for one message.
```

The `attach` button is the only intake path (no drag-drop or paste handler), so the guard has no bypass.

## Deliberate choices

- **An unsupported media type is not rejected locally** — DSH answers that case with its own reason, and duplicating the type list would let the two drift.
- **A payload missing any usable bound leaves intake unguarded**, rather than enforcing a limit the runtime never stated.
- `imageSizeText` falls back to KB under 1 MiB, so a small bound never renders as `0 MB`.

## Also here

A regression test pinning `webArgsForDshVersion` on the 0.1.1 release candidates. It is the extension's only version-parsed branch and its coverage stopped at `0.1.0`; it already answered correctly for `0.1.1-rc.x`, but nothing held that.

## Not included

Gating attachment on model image capability. The default `deepseek-v4-flash` refuses images at prompt admission (only `deepseek-v4-flash-vision-exp` accepts them), but `session.models` does not expose `inputModalities` on the wire — the official web client does not pre-flight this either.

`ImageAttachmentRef.originalDimensions`, new in 0.1.1, is not parsed: observing it requires a committed image through a vision model, which needs an API key, and I would rather not ship a field parser that has never seen real output.

## Test plan

- `pnpm run check` — typecheck, 122 tests, build all green
- 9 new tests in `tests/image-limits.spec.ts`, including the verbatim 0.1.1-rc.2 projection payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)