### PR TITLE
fix: preserve unknown slash-prefixed prompts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -416,7 +416,6 @@ class DshChatController implements vscode.Disposable {
       }
       return
     }
-    if (slash.kind === 'unknown') throw new Error(`Unknown DeepSeek command or skill: ${slash.token}`)
     await this.requireClient().prompt(
       this._state.sessionId,
       slash.kind === 'skill' || ideContext === undefined ? normalized : withIdeContext(normalized, ideContext),

--- a/src/slash-routing.ts
+++ b/src/slash-routing.ts
@@ -5,10 +5,9 @@ export interface NamedSlashSource {
 export type SlashRoute =
   | { kind: 'command'; name: string; token: string }
   | { kind: 'skill'; name: string; token: string }
-  | { kind: 'unknown'; token: string }
   | { kind: 'prompt' }
 
-/** Resolves a slash-prefixed composer value using the same command-before-skill precedence as DSH. */
+/** Resolves only catalog-backed slash names; every miss remains ordinary user text. */
 export function routeSlashInput(
   text: string,
   commands: readonly NamedSlashSource[],
@@ -18,8 +17,8 @@ export function routeSlashInput(
   if (!normalized.startsWith('/')) return { kind: 'prompt' }
   const token = normalized.split(/\s/, 1)[0] ?? normalized
   const name = /^\/([a-z0-9-]+)$/.exec(token)?.[1]
-  if (name === undefined) return { kind: 'unknown', token }
+  if (name === undefined) return { kind: 'prompt' }
   if (commands.some(command => command.name === name)) return { kind: 'command', name, token }
   if (skills.some(skill => skill.name === name)) return { kind: 'skill', name, token }
-  return { kind: 'unknown', token }
+  return { kind: 'prompt' }
 }

--- a/tests/slash-routing.spec.ts
+++ b/tests/slash-routing.spec.ts
@@ -21,11 +21,11 @@ describe('slash input routing', () => {
     })
   })
 
-  it('rejects unknown slash tokens without affecting ordinary prompts', () => {
-    expect(routeSlashInput('/not-installed', commands, skills)).toEqual({
-      kind: 'unknown',
-      token: '/not-installed',
-    })
+  it('keeps unknown slash-prefixed text in the ordinary prompt path', () => {
+    expect(routeSlashInput('/not-installed', commands, skills)).toEqual({ kind: 'prompt' })
+    expect(routeSlashInput('/* pasted comment */', commands, skills)).toEqual({ kind: 'prompt' })
+    expect(routeSlashInput('// pasted comment', commands, skills)).toEqual({ kind: 'prompt' })
+    expect(routeSlashInput('/api/users', commands, skills)).toEqual({ kind: 'prompt' })
     expect(routeSlashInput('explain this file', commands, skills)).toEqual({ kind: 'prompt' })
   })
 


### PR DESCRIPTION
## Summary

- route only catalog-backed DSH commands and skills through slash handling
- send unknown slash-prefixed text such as `/*`, `//`, `/hello`, and `/api/users` as ordinary prompts
- add regression coverage for pasted comments and path-like input

Closes #14

## Testing

- `npm run check` (22 test files, 123 tests)