### PR TITLE
feat: add autonomous VS Code debugging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode/**
 src/**
 tests/**
+scripts/**
 coverage/**
 node_modules/**
 website/**

--- a/package.json
+++ b/package.json
@@ -195,6 +195,12 @@
           "default": true,
           "description": "Reuse a healthy official DSH Web runtime on 127.0.0.1:3080 when no custom executable or arguments are configured."
         },
+        "deepseekHarness.autonomousDebugging": {
+          "type": "boolean",
+          "scope": "resource",
+          "default": false,
+          "markdownDescription": "Expose the current workspace's native VS Code debugger to DSH as autonomous tools. When enabled, the extension starts a managed DSH runtime instead of reusing an external runtime."
+        },
         "deepseekHarness.startupTimeout": {
           "type": "number",
           "scope": "resource",
@@ -207,10 +213,11 @@
     }
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "vscode:prepublish": "npm run build",
+    "build": "tsc -p tsconfig.json --noEmit && node scripts/build.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run --config vitest.config.ts",
-    "check": "tsc -p tsconfig.json --noEmit && vitest run --config vitest.config.ts && tsc -p tsconfig.json",
+    "check": "tsc -p tsconfig.json --noEmit && vitest run --config vitest.config.ts && node scripts/build.mjs",
     "package": "vsce package --readme-path README.marketplace.md --out dsh-vscode.vsix",
     "publish:marketplace": "vsce publish --readme-path README.marketplace.md"
   },
@@ -218,7 +225,10 @@
     "@types/node": "^22.20.0",
     "@types/vscode": "^1.100.0",
     "@vscode/vsce": "^3.6.0",
+    "@modelcontextprotocol/sdk": "1.30.0",
+    "esbuild": "^0.25.12",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "zod": "^3.25.76"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.30.0
+        version: 1.30.0(zod@3.25.76)
       '@types/node':
         specifier: ^22.20.0
         version: 22.20.1
@@ -17,12 +20,18 @@ importers:
       '@vscode/vsce':
         specifier: ^3.6.0
         version: 3.9.2
+      esbuild:
+        specifier: ^0.25.12
+        version: 0.25.12
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1))
+        version: 4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.25.12))
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
 
 packages:
 
@@ -84,8 +93,180 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@2.1.1':
+    resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.30.0':
+    resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -370,9 +551,21 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
@@ -424,6 +617,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -450,6 +647,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -500,8 +701,36 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.1.0:
+    resolution: {integrity: sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -543,6 +772,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -571,8 +804,15 @@ packages:
     resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
     engines: {ecmascript: '>= es5', node: '>=4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -615,8 +855,28 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -625,6 +885,16 @@ packages:
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.6.2:
+    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -652,9 +922,21 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -717,6 +999,10 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hono@4.13.3:
+    resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -728,6 +1014,10 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -738,6 +1028,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -756,6 +1050,14 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -783,13 +1085,22 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
   istextorbinary@9.5.0:
     resolution: {integrity: sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==}
     engines: {node: '>=4'}
+
+  jose@6.2.10:
+    resolution: {integrity: sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -800,6 +1111,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -958,6 +1272,14 @@ packages:
   mdurl@2.1.0:
     resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -970,9 +1292,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -1011,6 +1341,10 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  negotiator@1.1.0:
+    resolution: {integrity: sha512-NMPBRMJgiQHjbd8phG3Vebdx4kZ1H121rbl5IkMqeOsahptB9BKo/d7oJ3zTXqTgagn2bWlNSXkh0QUGM31RYg==}
+    engines: {node: '>=18'}
+
   node-abi@3.94.0:
     resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
     engines: {node: '>=10'}
@@ -1029,6 +1363,10 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -1036,6 +1374,10 @@ packages:
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1064,9 +1406,20 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
@@ -1089,6 +1442,10 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
 
@@ -1106,6 +1463,10 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -1119,6 +1480,14 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc-config-loader@4.1.4:
     resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
@@ -1152,6 +1521,10 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -1182,6 +1555,25 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -1234,6 +1626,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -1313,6 +1709,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -1326,6 +1726,10 @@ packages:
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typed-rest-client@1.8.11:
     resolution: {integrity: sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==}
@@ -1360,6 +1764,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
@@ -1368,6 +1776,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   version-range@4.15.0:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
@@ -1466,6 +1878,11 @@ packages:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1495,6 +1912,14 @@ packages:
 
   yazl@2.5.1:
     resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1594,7 +2019,111 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@hono/node-server@2.1.1(hono@4.13.3)':
+    dependencies:
+      hono: 4.13.3
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 2.1.1(hono@4.13.3)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.1
+      express: 5.2.1
+      express-rate-limit: 8.6.2(express@5.2.1)
+      hono: 4.13.3
+      jose: 6.2.10
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1796,13 +2325,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.20.1))':
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.25.12))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.1(@types/node@22.20.1)
+      vite: 8.2.1(@types/node@22.20.1)(esbuild@0.25.12)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1903,7 +2432,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.1.0
+
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
 
   ajv@8.20.0:
     dependencies:
@@ -1953,6 +2491,20 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.1.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   boundary@2.0.0: {}
@@ -1978,6 +2530,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -2038,7 +2592,28 @@ snapshots:
 
   commander@12.1.0: {}
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.1.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-select@5.2.2:
     dependencies:
@@ -2072,6 +2647,8 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
 
   detect-libc@2.1.2: {}
 
@@ -2107,7 +2684,11 @@ snapshots:
     dependencies:
       version-range: 4.15.0
 
+  ee-first@1.1.1: {}
+
   emoji-regex@8.0.0: {}
+
+  encodeurl@2.0.0: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -2144,14 +2725,94 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.4
 
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.1: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.1
 
   expand-template@2.0.3:
     optional: true
 
   expect-type@1.4.0: {}
+
+  express-rate-limit@8.6.2(express@5.2.1):
+    dependencies:
+      debug: 4.4.3
+      express: 5.2.1
+      ip-address: 10.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -2177,6 +2838,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -2184,6 +2856,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -2255,6 +2931,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.13.3: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -2269,6 +2947,14 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       entities: 7.0.1
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -2288,6 +2974,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1:
     optional: true
 
@@ -2295,11 +2985,14 @@ snapshots:
 
   index-to-position@1.2.0: {}
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
+
+  ip-address@10.5.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-docker@3.0.0: {}
 
@@ -2317,15 +3010,21 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-promise@4.0.0: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
 
   istextorbinary@9.5.0:
     dependencies:
       binaryextensions: 6.11.0
       editions: 6.22.0
       textextensions: 6.11.0
+
+  jose@6.2.10: {}
 
   js-tokens@4.0.0: {}
 
@@ -2334,6 +3033,8 @@ snapshots:
       argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json5@2.2.3: {}
 
@@ -2473,6 +3174,10 @@ snapshots:
 
   mdurl@2.1.0: {}
 
+  media-typer@1.1.1: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -2482,9 +3187,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -2512,6 +3223,10 @@ snapshots:
   napi-build-utils@2.0.0:
     optional: true
 
+  negotiator@1.1.0:
+    dependencies:
+      content-type: 2.1.0
+
   node-abi@3.94.0:
     dependencies:
       semver: 7.8.5
@@ -2535,14 +3250,19 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   obug@2.1.4: {}
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   open@10.2.0:
     dependencies:
@@ -2576,10 +3296,16 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   path-type@6.0.0: {}
 
@@ -2592,6 +3318,8 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
+
+  pkce-challenge@5.0.1: {}
 
   pluralize@2.0.0: {}
 
@@ -2619,6 +3347,11 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -2633,6 +3366,15 @@ snapshots:
       side-channel: 1.1.1
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
 
   rc-config-loader@4.1.4:
     dependencies:
@@ -2694,6 +3436,16 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.4
       '@rolldown/binding-win32-x64-msvc': 1.2.4
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -2721,6 +3473,39 @@ snapshots:
   semver@5.7.2: {}
 
   semver@7.8.5: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -2787,6 +3572,8 @@ snapshots:
   spdx-license-ids@3.0.23: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.2.0: {}
 
@@ -2878,6 +3665,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
@@ -2888,6 +3677,12 @@ snapshots:
   tunnel@0.0.6: {}
 
   type-fest@4.41.0: {}
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.1.0
+      media-typer: 1.1.1
+      mime-types: 3.0.2
 
   typed-rest-client@1.8.11:
     dependencies:
@@ -2911,6 +3706,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   url-join@4.0.1: {}
 
   util-deprecate@1.0.2:
@@ -2921,9 +3718,11 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  vary@1.1.2: {}
+
   version-range@4.15.0: {}
 
-  vite@8.2.1(@types/node@22.20.1):
+  vite@8.2.1(@types/node@22.20.1)(esbuild@0.25.12):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -2932,12 +3731,13 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.20.1
+      esbuild: 0.25.12
       fsevents: 2.3.3
 
-  vitest@4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)):
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.25.12)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1))
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.25.12))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -2954,7 +3754,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.1(@types/node@22.20.1)
+      vite: 8.2.1(@types/node@22.20.1)(esbuild@0.25.12)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
@@ -2967,13 +3767,16 @@ snapshots:
 
   whatwg-mimetype@4.0.0: {}
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrappy@1.0.2:
-    optional: true
+  wrappy@1.0.2: {}
 
   wsl-utils@0.1.0:
     dependencies:
@@ -2995,3 +3798,9 @@ snapshots:
   yazl@2.5.1:
     dependencies:
       buffer-crc32: 0.2.13
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   '@vscode/vsce-sign': true
+  esbuild: true
   keytar: true

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,0 +1,19 @@
+import { build } from 'esbuild'
+import { rm } from 'node:fs/promises'
+
+await rm(new URL('../dist/', import.meta.url), { recursive: true, force: true })
+
+await build({
+  entryPoints: { extension: 'src/extension.ts' },
+  outdir: 'dist',
+  entryNames: '[name]',
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node22',
+  external: ['vscode'],
+  minify: true,
+  sourcemap: true,
+  legalComments: 'none',
+  logLevel: 'info',
+})

--- a/src/debug-mcp-server.ts
+++ b/src/debug-mcp-server.ts
@@ -1,0 +1,203 @@
+import { randomBytes, randomUUID, timingSafeEqual } from 'node:crypto'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { z } from 'zod'
+import type {
+  DebugBreakpointInput,
+  DebugBreakpointResult,
+  DebugContextResult,
+  DebugControlInput,
+  DebugStartInput,
+  DebugStartResult,
+} from './debug-tools.js'
+import type { DebugSessionSnapshot } from './debug-session-manager.js'
+
+const MAX_REQUEST_BYTES = 256 * 1024
+
+export interface DebugToolHandler {
+  start(input?: DebugStartInput): Promise<DebugStartResult>
+  breakpoint(input: DebugBreakpointInput): Promise<DebugBreakpointResult>
+  control(input: DebugControlInput): Promise<DebugSessionSnapshot>
+  context(): Promise<DebugContextResult>
+}
+
+export interface DebugMcpLogger {
+  appendLine(value: string): void
+}
+
+function textResult(value: unknown): { content: Array<{ type: 'text'; text: string }> } {
+  return { content: [{ type: 'text', text: JSON.stringify(value) }] }
+}
+
+function tokenMatches(header: string | undefined, token: string): boolean {
+  if (header === undefined || !header.startsWith('Bearer ')) return false
+  const candidate = Buffer.from(header.slice('Bearer '.length))
+  const expected = Buffer.from(token)
+  return candidate.length === expected.length && timingSafeEqual(candidate, expected)
+}
+
+async function requestBody(request: IncomingMessage): Promise<unknown> {
+  const declaredLength = Number(request.headers['content-length'] ?? 0)
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_REQUEST_BYTES) throw new Error('MCP request body is too large.')
+  const chunks: Buffer[] = []
+  let length = 0
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as Uint8Array)
+    length += buffer.length
+    if (length > MAX_REQUEST_BYTES) throw new Error('MCP request body is too large.')
+    chunks.push(buffer)
+  }
+  if (chunks.length === 0) return undefined
+  return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown
+}
+
+function closeHttpServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve()
+  return new Promise(resolve => {
+    server.close(() => { resolve() })
+    server.closeAllConnections()
+  })
+}
+
+/** Authenticated, loopback-only MCP endpoint for one managed DSH runtime. */
+export class DebugMcpServer implements AsyncDisposable {
+  private readonly token = randomBytes(32).toString('base64url')
+  private readonly mcp = new McpServer({ name: 'dsh-vscode-debug', version: '1.0.0' })
+  private readonly http: Server
+  private transport: StreamableHTTPServerTransport | undefined
+  private endpointValue: URL | undefined
+  private disposed = false
+
+  constructor(
+    private readonly tools: DebugToolHandler,
+    private readonly logger?: DebugMcpLogger,
+  ) {
+    this.registerTools()
+    this.http = createServer((request, response) => {
+      void this.handleRequest(request, response)
+    })
+  }
+
+  get authorizationToken(): string {
+    return this.token
+  }
+
+  get endpoint(): URL {
+    if (this.endpointValue === undefined) throw new Error('The debug MCP server has not started.')
+    return this.endpointValue
+  }
+
+  async start(): Promise<URL> {
+    if (this.endpointValue !== undefined) return this.endpointValue
+    if (this.disposed) throw new Error('The debug MCP server has been disposed.')
+
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error): void => {
+        this.http.off('listening', onListening)
+        reject(error)
+      }
+      const onListening = (): void => {
+        this.http.off('error', onError)
+        resolve()
+      }
+      this.http.once('error', onError)
+      this.http.once('listening', onListening)
+      this.http.listen(0, '127.0.0.1')
+    })
+    const address = this.http.address() as AddressInfo
+    const host = `127.0.0.1:${String(address.port)}`
+    this.transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: randomUUID,
+      enableJsonResponse: true,
+      allowedHosts: [host],
+      enableDnsRebindingProtection: true,
+    })
+    // SDK v1's Transport callbacks predate exactOptionalPropertyTypes and are
+    // structurally compatible at runtime despite the narrower declaration.
+    await this.mcp.connect(this.transport as unknown as Transport)
+    this.endpointValue = new URL(`http://${host}/mcp`)
+    this.logger?.appendLine(`[debug] MCP bridge listening on ${this.endpointValue.href}`)
+    return this.endpointValue
+  }
+
+  private registerTools(): void {
+    this.mcp.registerTool('debug_start', {
+      description: 'Start the current VS Code project under its existing launch.json debugger. Use this autonomously when a bug depends on runtime state, a value becomes wrong before the failure, or execution hangs. If multiple configurations are returned, call again with one configuration name.',
+      inputSchema: {
+        configuration: z.string().trim().min(1).optional().describe('Existing launch.json configuration name. Omit when the workspace has exactly one configuration.'),
+      },
+    }, async input => textResult(await this.tools.start(input)))
+
+    this.mcp.registerTool('debug_breakpoint', {
+      description: 'Add, remove, or list VS Code source breakpoints owned by this debugging session. Lines are 1-based. Set a breakpoint before debug_start when you know where an incorrect value is produced.',
+      inputSchema: {
+        action: z.enum(['add', 'remove', 'list']),
+        path: z.string().trim().min(1).optional().describe('Workspace-relative source file path for add.'),
+        line: z.number().int().positive().optional().describe('1-based source line for add.'),
+        breakpointId: z.string().trim().min(1).optional().describe('Bridge-owned breakpoint ID for remove.'),
+      },
+    }, async input => textResult(await this.tools.breakpoint(input)))
+
+    this.mcp.registerTool('debug_control', {
+      description: 'Control the DeepSeek-owned VS Code debug session. Continue or step only while paused; use pause for a running or hung program, and stop when the investigation is complete. A running result after an action means execution has not reached another stop yet.',
+      inputSchema: {
+        action: z.enum(['continue', 'pause', 'next', 'stepIn', 'stepOut', 'stop']),
+      },
+    }, async input => textResult(await this.tools.control(input)))
+
+    this.mcp.registerTool('debug_context', {
+      description: 'Read the current paused VS Code debugger context: stop reason, source location, compact stack, and bounded local variables. Call after a breakpoint, pause, or step before deciding how to edit the code.',
+      inputSchema: {},
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    }, async () => textResult(await this.tools.context()))
+  }
+
+  private async handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    try {
+      if (this.transport === undefined || this.endpointValue === undefined) throw new Error('Debug MCP bridge is not ready.')
+      const requestUrl = new URL(request.url ?? '/', this.endpointValue)
+      if (requestUrl.pathname !== '/mcp') {
+        response.writeHead(404).end('Not found')
+        return
+      }
+      if (request.headers.host !== this.endpointValue.host) {
+        response.writeHead(403).end('Invalid host')
+        return
+      }
+      const authorization = Array.isArray(request.headers.authorization)
+        ? request.headers.authorization[0]
+        : request.headers.authorization
+      if (!tokenMatches(authorization, this.token)) {
+        response.writeHead(401, { 'www-authenticate': 'Bearer' }).end('Unauthorized')
+        return
+      }
+      const parsedBody = request.method === 'POST' ? await requestBody(request) : undefined
+      await this.transport.handleRequest(request, response, parsedBody)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.logger?.appendLine(`[debug] MCP request failed: ${message}`)
+      if (!response.headersSent) {
+        response.writeHead(message.includes('too large') ? 413 : 500, { 'content-type': 'application/json' })
+        response.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message }, id: null }))
+      } else if (!response.writableEnded) {
+        response.end()
+      }
+    }
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return
+    this.disposed = true
+    this.endpointValue = undefined
+    await closeHttpServer(this.http)
+    await this.mcp.close()
+    this.transport = undefined
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    await this.dispose()
+  }
+}

--- a/src/debug-mcp-server.ts
+++ b/src/debug-mcp-server.ts
@@ -125,7 +125,7 @@ export class DebugMcpServer implements AsyncDisposable {
 
   private registerTools(): void {
     this.mcp.registerTool('debug_start', {
-      description: 'Start the current VS Code project under its existing launch.json debugger. Use this autonomously when a bug depends on runtime state, a value becomes wrong before the failure, or execution hangs. If multiple configurations are returned, call again with one configuration name.',
+      description: 'Start the current VS Code project under its existing launch.json debugger. Use this autonomously when a bug depends on runtime state, a value becomes wrong before the failure, or execution hangs. If multiple configurations are returned, call again with one configuration name. A completed status means the program exited before it could pause and does not require debug_context.',
       inputSchema: {
         configuration: z.string().trim().min(1).optional().describe('Existing launch.json configuration name. Omit when the workspace has exactly one configuration.'),
       },
@@ -149,7 +149,7 @@ export class DebugMcpServer implements AsyncDisposable {
     }, async input => textResult(await this.tools.control(input)))
 
     this.mcp.registerTool('debug_context', {
-      description: 'Read the current paused VS Code debugger context: stop reason, source location, compact stack, and bounded local variables. Call after a breakpoint, pause, or step before deciding how to edit the code.',
+      description: 'Read the current paused VS Code debugger context: stop reason, source location, compact application stack, and bounded local variables. Call after a breakpoint, pause, or step before deciding how to edit the code. If the program already finished, this returns its terminated session without treating normal completion as an error.',
       inputSchema: {},
       annotations: { readOnlyHint: true, openWorldHint: false },
     }, async () => textResult(await this.tools.context()))

--- a/src/debug-runtime-contribution.ts
+++ b/src/debug-runtime-contribution.ts
@@ -1,0 +1,63 @@
+import { randomUUID } from 'node:crypto'
+import { mkdir, unlink, writeFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+import { DebugMcpServer, type DebugMcpLogger } from './debug-mcp-server.js'
+import { debugRuntimePatch, injectDebugRuntimePatch, supportsDebugRuntime } from './debug-runtime-patch.js'
+import type { DebugToolHandler } from './debug-mcp-server.js'
+import type { RuntimeLaunchContext, RuntimeLaunchContributor, RuntimeLaunchPreparation } from './runtime-launch.js'
+
+const DEBUG_TOKEN_ENV = 'DSH_VSCODE_DEBUG_TOKEN'
+
+async function removeFile(filePath: string): Promise<void> {
+  try {
+    await unlink(filePath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+}
+
+/** Starts the debug MCP bridge and overlays it into managed DSH launches. */
+export class DebugRuntimeContribution implements RuntimeLaunchContributor {
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly workspace: vscode.WorkspaceFolder,
+    private readonly tools: DebugToolHandler,
+    private readonly logger?: DebugMcpLogger,
+  ) {}
+
+  async prepare(_launch: RuntimeLaunchContext): Promise<RuntimeLaunchPreparation | undefined> {
+    const enabled = vscode.workspace
+      .getConfiguration('deepseekHarness', this.workspace.uri)
+      .get<boolean>('autonomousDebugging', false)
+    if (!enabled) return undefined
+
+    const bridge = new DebugMcpServer(this.tools, this.logger)
+    let patchPath: string | undefined
+    try {
+      const endpoint = await bridge.start()
+      const storage = this.context.storageUri ?? this.context.globalStorageUri
+      await mkdir(storage.fsPath, { recursive: true })
+      patchPath = path.join(storage.fsPath, `debug-${randomUUID()}.cordis.yml`)
+      await writeFile(patchPath, debugRuntimePatch(endpoint), { encoding: 'utf8', mode: 0o600 })
+      const finalPatchPath = patchPath
+      return {
+        environment: { [DEBUG_TOKEN_ENV]: bridge.authorizationToken },
+        transformArguments: (args, version) => {
+          if (!supportsDebugRuntime(version)) {
+            throw new Error('Autonomous debugging requires DeepSeek Harness 0.1.0-rc.8 or later.')
+          }
+          return injectDebugRuntimePatch(args, finalPatchPath)
+        },
+        dispose: async () => {
+          await bridge.dispose()
+          await removeFile(finalPatchPath)
+        },
+      }
+    } catch (error) {
+      await bridge.dispose()
+      if (patchPath !== undefined) await removeFile(patchPath)
+      throw error
+    }
+  }
+}

--- a/src/debug-runtime-contribution.ts
+++ b/src/debug-runtime-contribution.ts
@@ -3,8 +3,10 @@ import { mkdir, unlink, writeFile } from 'node:fs/promises'
 import * as path from 'node:path'
 import * as vscode from 'vscode'
 import { DebugMcpServer, type DebugMcpLogger } from './debug-mcp-server.js'
+import { DebugTools } from './debug-tools.js'
+import type { DebugSessionManager } from './debug-session-manager.js'
 import { debugRuntimePatch, injectDebugRuntimePatch, supportsDebugRuntime } from './debug-runtime-patch.js'
-import type { DebugToolHandler } from './debug-mcp-server.js'
+import { debugWorkspaceForPath } from './debug-workspace.js'
 import type { RuntimeLaunchContext, RuntimeLaunchContributor, RuntimeLaunchPreparation } from './runtime-launch.js'
 
 const DEBUG_TOKEN_ENV = 'DSH_VSCODE_DEBUG_TOKEN'
@@ -21,19 +23,32 @@ async function removeFile(filePath: string): Promise<void> {
 export class DebugRuntimeContribution implements RuntimeLaunchContributor {
   constructor(
     private readonly context: vscode.ExtensionContext,
-    private readonly workspace: vscode.WorkspaceFolder,
-    private readonly tools: DebugToolHandler,
+    private readonly sessions: DebugSessionManager,
     private readonly logger?: DebugMcpLogger,
   ) {}
 
-  async prepare(_launch: RuntimeLaunchContext): Promise<RuntimeLaunchPreparation | undefined> {
+  async prepare(launch: RuntimeLaunchContext): Promise<RuntimeLaunchPreparation | undefined> {
+    const workspace = debugWorkspaceForPath(vscode.workspace.workspaceFolders ?? [], launch.workspacePath)
+    if (workspace === undefined) throw new Error('The selected DeepSeek project is not an open VS Code workspace folder.')
     const enabled = vscode.workspace
-      .getConfiguration('deepseekHarness', this.workspace.uri)
+      .getConfiguration('deepseekHarness', workspace.uri)
       .get<boolean>('autonomousDebugging', false)
     if (!enabled) return undefined
 
-    const bridge = new DebugMcpServer(this.tools, this.logger)
+    const tools = new DebugTools(this.sessions, workspace)
+    const bridge = new DebugMcpServer(tools, this.logger)
     let patchPath: string | undefined
+    const dispose = async (): Promise<void> => {
+      try {
+        await bridge.dispose()
+      } finally {
+        try {
+          if (patchPath !== undefined) await removeFile(patchPath)
+        } finally {
+          tools.dispose()
+        }
+      }
+    }
     try {
       const endpoint = await bridge.start()
       const storage = this.context.storageUri ?? this.context.globalStorageUri
@@ -49,14 +64,10 @@ export class DebugRuntimeContribution implements RuntimeLaunchContributor {
           }
           return injectDebugRuntimePatch(args, finalPatchPath)
         },
-        dispose: async () => {
-          await bridge.dispose()
-          await removeFile(finalPatchPath)
-        },
+        dispose,
       }
     } catch (error) {
-      await bridge.dispose()
-      if (patchPath !== undefined) await removeFile(patchPath)
+      await dispose()
       throw error
     }
   }

--- a/src/debug-runtime-contribution.ts
+++ b/src/debug-runtime-contribution.ts
@@ -43,9 +43,13 @@ export class DebugRuntimeContribution implements RuntimeLaunchContributor {
         await bridge.dispose()
       } finally {
         try {
-          if (patchPath !== undefined) await removeFile(patchPath)
+          await this.sessions.stopOwnedSessions(workspace)
         } finally {
-          tools.dispose()
+          try {
+            if (patchPath !== undefined) await removeFile(patchPath)
+          } finally {
+            tools.dispose()
+          }
         }
       }
     }

--- a/src/debug-runtime-patch.ts
+++ b/src/debug-runtime-patch.ts
@@ -1,0 +1,47 @@
+export function injectDebugRuntimePatch(args: readonly string[], patchPath: string): string[] {
+  if (patchPath.trim() === '') throw new Error('The debug runtime patch path is empty.')
+  if (args.some((arg, index) => arg === '--patch' && args[index + 1] === patchPath)) return [...args]
+
+  if (args[0] === 'web') return ['web', '--patch', patchPath, ...args.slice(1)]
+  if (args[0] === '--profile' && args[1] === 'web') {
+    return ['--profile', 'web', '--patch', patchPath, ...args.slice(2)]
+  }
+  throw new Error('Autonomous debugging requires the DSH Web profile (`dsh web` or `dsh --profile web`).')
+}
+
+export function supportsDebugRuntime(version: string | undefined): boolean {
+  if (version === undefined || version.trim() === '') return true
+  const match = /(?:^|\s|v)(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?(?:\s|$|\+)/i.exec(version.trim())
+  if (match === null) return true
+  const major = Number(match[1])
+  const minor = Number(match[2])
+  const patch = Number(match[3])
+  const rc = match[4] === undefined ? undefined : Number(match[4])
+  if (major > 0 || minor > 1 || patch > 0) return true
+  return rc === undefined || rc >= 8
+}
+
+export function debugRuntimePatch(endpoint: URL): string {
+  if (endpoint.protocol !== 'http:' || endpoint.hostname !== '127.0.0.1') {
+    throw new Error('The debug MCP endpoint must use the IPv4 loopback address.')
+  }
+  return [
+    '- insert:',
+    '    - id: dsh-vscode-debug',
+    "      name: '@deepseek-ai/dsh-mcp-client'",
+    '      config:',
+    '        serverName: vscode',
+    '        transport: streamable-http',
+    `        url: ${endpoint.href}`,
+    '        headers:',
+    "          Authorization: !!js '`Bearer ${process.env.DSH_VSCODE_DEBUG_TOKEN}`'",
+    '        toolCallTimeoutMs: 15000',
+    '        failOnStartupError: false',
+    '        reconnect:',
+    '          enabled: true',
+    '          initialDelayMs: 500',
+    '          maxDelayMs: 10000',
+    '          maxAttempts: 10',
+    '',
+  ].join('\n')
+}

--- a/src/debug-runtime-patch.ts
+++ b/src/debug-runtime-patch.ts
@@ -17,7 +17,9 @@ export function supportsDebugRuntime(version: string | undefined): boolean {
   const minor = Number(match[2])
   const patch = Number(match[3])
   const rc = match[4] === undefined ? undefined : Number(match[4])
-  if (major > 0 || minor > 1 || patch > 0) return true
+  if (major !== 0) return major > 0
+  if (minor !== 1) return minor > 1
+  if (patch !== 0) return patch > 0
   return rc === undefined || rc >= 8
 }
 

--- a/src/debug-session-manager.ts
+++ b/src/debug-session-manager.ts
@@ -46,6 +46,9 @@ export class DebugSessionManager implements vscode.Disposable {
   beginLaunch(folder: vscode.WorkspaceFolder): void {
     if (this.pendingWorkspace !== undefined) throw new Error('A DeepSeek debug launch is already starting.')
     if (this.preferredSession() !== undefined) throw new Error('Stop the current DeepSeek debug session before starting another one.')
+    for (const [sessionId, owned] of this.owned) {
+      if (owned.state.phase === 'terminated') this.owned.delete(sessionId)
+    }
     this.pendingWorkspace = workspaceKey(folder)
   }
 
@@ -121,7 +124,6 @@ export class DebugSessionManager implements vscode.Disposable {
     if (owned === undefined) return
     owned.state = { phase: 'terminated', stopEpoch: owned.state.stopEpoch, threads: {} }
     this.publish(owned)
-    this.owned.delete(session.id)
   }
 
   private acceptMessage(session: vscode.DebugSession, message: unknown): void {

--- a/src/debug-session-manager.ts
+++ b/src/debug-session-manager.ts
@@ -8,6 +8,7 @@ import {
 
 interface OwnedDebugSession {
   readonly session: vscode.DebugSession
+  readonly workspace: string
   state: DebugSessionState
 }
 
@@ -157,11 +158,35 @@ export class DebugSessionManager implements vscode.Disposable {
     })
   }
 
+  async stopOwnedSessions(folder: vscode.WorkspaceFolder): Promise<void> {
+    const workspace = workspaceKey(folder)
+    if (workspace === undefined) return
+    if (this.pendingWorkspace === workspace) this.pendingWorkspace = undefined
+    const selected = [...this.owned.values()].filter(owned => owned.workspace === workspace)
+    const selectedIds = new Set(selected.map(owned => owned.session.id))
+    const active = selected.filter(owned => owned.state.phase !== 'terminated')
+    const activeIds = new Set(active.map(owned => owned.session.id))
+    const roots = active.filter(owned => {
+      const parentId = owned.session.parentSession?.id
+      return parentId === undefined || !activeIds.has(parentId)
+    })
+    // Detach before awaiting VS Code so late child-session events cannot be
+    // adopted by a bridge that is already shutting down.
+    for (const sessionId of selectedIds) this.owned.delete(sessionId)
+    const results = await Promise.allSettled(roots.map(async owned => { await vscode.debug.stopDebugging(owned.session) }))
+    const failures = results.filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+    if (failures.length > 0) {
+      const detail = failures.map(result => result.reason instanceof Error ? result.reason.message : String(result.reason)).join('; ')
+      throw new Error(`Could not stop every DeepSeek debug session: ${detail}`)
+    }
+  }
+
   private acceptStartedSession(session: vscode.DebugSession): void {
-    const parentOwned = session.parentSession !== undefined && this.owned.has(session.parentSession.id)
+    const parent = session.parentSession === undefined ? undefined : this.owned.get(session.parentSession.id)
+    const parentOwned = parent !== undefined
     const pendingMatch = this.pendingWorkspace !== undefined && workspaceKey(session.workspaceFolder) === this.pendingWorkspace
     if (!parentOwned && !pendingMatch) return
-    this.ensureOwned(session)
+    this.ensureOwned(session, parent?.workspace ?? this.pendingWorkspace)
   }
 
   private acceptTerminatedSession(session: vscode.DebugSession): void {
@@ -172,20 +197,23 @@ export class DebugSessionManager implements vscode.Disposable {
   }
 
   private acceptMessage(session: vscode.DebugSession, message: unknown): void {
-    const parentOwned = session.parentSession !== undefined && this.owned.has(session.parentSession.id)
+    const parent = session.parentSession === undefined ? undefined : this.owned.get(session.parentSession.id)
+    const parentOwned = parent !== undefined
     const pendingMatch = this.pendingWorkspace !== undefined && workspaceKey(session.workspaceFolder) === this.pendingWorkspace
     if (!this.owned.has(session.id) && !parentOwned && !pendingMatch) return
-    const owned = this.ensureOwned(session)
+    const existing = this.owned.get(session.id)
+    const owned = existing ?? this.ensureOwned(session, parent?.workspace ?? this.pendingWorkspace)
     const next = reduceDebugAdapterMessage(owned.state, message)
     if (next === owned.state) return
     owned.state = next
     this.publish(owned)
   }
 
-  private ensureOwned(session: vscode.DebugSession): OwnedDebugSession {
+  private ensureOwned(session: vscode.DebugSession, workspace?: string): OwnedDebugSession {
     const existing = this.owned.get(session.id)
     if (existing !== undefined) return existing
-    const owned = { session, state: initialDebugSessionState() }
+    if (workspace === undefined) throw new Error('Cannot own a debug session without its launch workspace.')
+    const owned = { session, workspace, state: initialDebugSessionState() }
     this.owned.set(session.id, owned)
     this.publish(owned)
     return owned

--- a/src/debug-session-manager.ts
+++ b/src/debug-session-manager.ts
@@ -1,0 +1,172 @@
+import * as vscode from 'vscode'
+import {
+  initialDebugSessionState,
+  reduceDebugAdapterMessage,
+  type DebugSessionPhase,
+  type DebugSessionState,
+} from './debug-state.js'
+
+interface OwnedDebugSession {
+  readonly session: vscode.DebugSession
+  state: DebugSessionState
+}
+
+export interface DebugSessionSnapshot extends DebugSessionState {
+  readonly sessionId: string
+  readonly name: string
+  readonly type: string
+}
+
+function workspaceKey(folder: vscode.WorkspaceFolder | undefined): string | undefined {
+  return folder?.uri.toString(true)
+}
+
+/** Tracks the single agent-owned debug launch without taking over user sessions. */
+export class DebugSessionManager implements vscode.Disposable {
+  private readonly disposables: vscode.Disposable[] = []
+  private readonly changes = new vscode.EventEmitter<DebugSessionSnapshot>()
+  private readonly owned = new Map<string, OwnedDebugSession>()
+  private pendingWorkspace: string | undefined
+
+  readonly onDidChangeState = this.changes.event
+
+  constructor() {
+    this.disposables.push(
+      vscode.debug.registerDebugAdapterTrackerFactory('*', {
+        createDebugAdapterTracker: session => ({
+          onWillReceiveMessage: message => { this.acceptMessage(session, message) },
+          onDidSendMessage: message => { this.acceptMessage(session, message) },
+        }),
+      }),
+      vscode.debug.onDidStartDebugSession(session => { this.acceptStartedSession(session) }),
+      vscode.debug.onDidTerminateDebugSession(session => { this.acceptTerminatedSession(session) }),
+    )
+  }
+
+  beginLaunch(folder: vscode.WorkspaceFolder): void {
+    if (this.pendingWorkspace !== undefined) throw new Error('A DeepSeek debug launch is already starting.')
+    if (this.preferredSession() !== undefined) throw new Error('Stop the current DeepSeek debug session before starting another one.')
+    this.pendingWorkspace = workspaceKey(folder)
+  }
+
+  completeLaunch(started: boolean): DebugSessionSnapshot | undefined {
+    this.pendingWorkspace = undefined
+    if (!started) return undefined
+    return this.snapshot()
+  }
+
+  cancelLaunch(): void {
+    this.pendingWorkspace = undefined
+  }
+
+  session(sessionId?: string): vscode.DebugSession | undefined {
+    return sessionId === undefined ? this.preferredSession()?.session : this.owned.get(sessionId)?.session
+  }
+
+  snapshot(sessionId?: string): DebugSessionSnapshot | undefined {
+    const owned = sessionId === undefined ? this.preferredSession() : this.owned.get(sessionId)
+    if (owned === undefined) return undefined
+    return {
+      sessionId: owned.session.id,
+      name: owned.session.name,
+      type: owned.session.type,
+      ...owned.state,
+    }
+  }
+
+  snapshots(): DebugSessionSnapshot[] {
+    return [...this.owned.values()]
+      .filter(item => item.state.phase !== 'terminated')
+      .map(item => ({ sessionId: item.session.id, name: item.session.name, type: item.session.type, ...item.state }))
+  }
+
+  async waitFor(
+    sessionId: string,
+    phases: readonly DebugSessionPhase[],
+    timeoutMs: number,
+  ): Promise<DebugSessionSnapshot> {
+    const current = this.snapshot(sessionId)
+    if (current === undefined) throw new Error('The DeepSeek debug session is no longer available.')
+    if (phases.includes(current.phase)) return current
+
+    return await new Promise<DebugSessionSnapshot>(resolve => {
+      let settled = false
+      const finish = (snapshot: DebugSessionSnapshot): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        subscription.dispose()
+        resolve(snapshot)
+      }
+      const subscription = this.onDidChangeState(snapshot => {
+        if (snapshot.sessionId === sessionId && phases.includes(snapshot.phase)) finish(snapshot)
+      })
+      const timer = setTimeout(() => {
+        const latest = this.snapshot(sessionId)
+        if (latest !== undefined) finish(latest)
+        else finish({ ...current, phase: 'terminated', threads: {} })
+      }, timeoutMs)
+    })
+  }
+
+  private acceptStartedSession(session: vscode.DebugSession): void {
+    const parentOwned = session.parentSession !== undefined && this.owned.has(session.parentSession.id)
+    const pendingMatch = this.pendingWorkspace !== undefined && workspaceKey(session.workspaceFolder) === this.pendingWorkspace
+    if (!parentOwned && !pendingMatch) return
+    this.ensureOwned(session)
+  }
+
+  private acceptTerminatedSession(session: vscode.DebugSession): void {
+    const owned = this.owned.get(session.id)
+    if (owned === undefined) return
+    owned.state = { phase: 'terminated', stopEpoch: owned.state.stopEpoch, threads: {} }
+    this.publish(owned)
+    this.owned.delete(session.id)
+  }
+
+  private acceptMessage(session: vscode.DebugSession, message: unknown): void {
+    const parentOwned = session.parentSession !== undefined && this.owned.has(session.parentSession.id)
+    const pendingMatch = this.pendingWorkspace !== undefined && workspaceKey(session.workspaceFolder) === this.pendingWorkspace
+    if (!this.owned.has(session.id) && !parentOwned && !pendingMatch) return
+    const owned = this.ensureOwned(session)
+    const next = reduceDebugAdapterMessage(owned.state, message)
+    if (next === owned.state) return
+    owned.state = next
+    this.publish(owned)
+  }
+
+  private ensureOwned(session: vscode.DebugSession): OwnedDebugSession {
+    const existing = this.owned.get(session.id)
+    if (existing !== undefined) return existing
+    const owned = { session, state: initialDebugSessionState() }
+    this.owned.set(session.id, owned)
+    this.publish(owned)
+    return owned
+  }
+
+  private preferredSession(): OwnedDebugSession | undefined {
+    const active = vscode.debug.activeDebugSession
+    if (active !== undefined) {
+      const owned = this.owned.get(active.id)
+      if (owned !== undefined && owned.state.phase !== 'terminated') return owned
+    }
+    return [...this.owned.values()].find(item => item.state.phase === 'stopped')
+      ?? [...this.owned.values()].find(item => item.state.phase !== 'terminated')
+  }
+
+  private publish(owned: OwnedDebugSession): void {
+    this.changes.fire({
+      sessionId: owned.session.id,
+      name: owned.session.name,
+      type: owned.session.type,
+      ...owned.state,
+    })
+  }
+
+  dispose(): void {
+    for (const disposable of this.disposables.splice(0)) disposable.dispose()
+    this.changes.dispose()
+    this.owned.clear()
+    this.pendingWorkspace = undefined
+  }
+}

--- a/src/debug-session-manager.ts
+++ b/src/debug-session-manager.ts
@@ -56,7 +56,7 @@ export class DebugSessionManager implements vscode.Disposable {
   completeLaunch(started: boolean): DebugSessionSnapshot | undefined {
     this.pendingWorkspace = undefined
     if (!started) return undefined
-    return this.snapshot()
+    return this.snapshot() ?? this.latestSnapshot()
   }
 
   cancelLaunch(): void {

--- a/src/debug-session-manager.ts
+++ b/src/debug-session-manager.ts
@@ -77,6 +77,51 @@ export class DebugSessionManager implements vscode.Disposable {
     }
   }
 
+  latestSnapshot(): DebugSessionSnapshot | undefined {
+    const owned = [...this.owned.values()].at(-1)
+    if (owned === undefined) return undefined
+    return {
+      sessionId: owned.session.id,
+      name: owned.session.name,
+      type: owned.session.type,
+      ...owned.state,
+    }
+  }
+
+  async waitForLaunchSettlement(timeoutMs: number): Promise<DebugSessionSnapshot | undefined> {
+    const settled = (): DebugSessionSnapshot | undefined => {
+      const stopped = [...this.owned.values()].find(item => item.state.phase === 'stopped')
+      if (stopped !== undefined) {
+        return {
+          sessionId: stopped.session.id,
+          name: stopped.session.name,
+          type: stopped.session.type,
+          ...stopped.state,
+        }
+      }
+      const running = [...this.owned.values()].some(item => item.state.phase !== 'terminated')
+      return running ? undefined : this.latestSnapshot()
+    }
+    const current = settled()
+    if (current !== undefined) return current
+
+    return await new Promise<DebugSessionSnapshot | undefined>(resolve => {
+      let finished = false
+      const finish = (snapshot: DebugSessionSnapshot | undefined): void => {
+        if (finished) return
+        finished = true
+        clearTimeout(timer)
+        subscription.dispose()
+        resolve(snapshot)
+      }
+      const subscription = this.onDidChangeState(() => {
+        const snapshot = settled()
+        if (snapshot !== undefined) finish(snapshot)
+      })
+      const timer = setTimeout(() => { finish(this.snapshot() ?? this.latestSnapshot()) }, timeoutMs)
+    })
+  }
+
   snapshots(): DebugSessionSnapshot[] {
     return [...this.owned.values()]
       .filter(item => item.state.phase !== 'terminated')

--- a/src/debug-state.ts
+++ b/src/debug-state.ts
@@ -1,0 +1,104 @@
+export type DebugSessionPhase = 'starting' | 'running' | 'stopped' | 'terminated'
+export type DebugThreadPhase = 'running' | 'stopped'
+
+export interface DebugSessionState {
+  readonly phase: DebugSessionPhase
+  readonly stopEpoch: number
+  readonly threads: Readonly<Record<string, DebugThreadPhase>>
+  readonly currentThreadId?: number
+  readonly stopReason?: string
+}
+
+export function initialDebugSessionState(): DebugSessionState {
+  return { phase: 'starting', stopEpoch: 0, threads: {} }
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : undefined
+}
+
+function number(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) ? value : undefined
+}
+
+function string(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined
+}
+
+function phaseForThreads(threads: Readonly<Record<string, DebugThreadPhase>>): DebugSessionPhase {
+  return Object.values(threads).includes('stopped') ? 'stopped' : 'running'
+}
+
+function markRunning(
+  state: DebugSessionState,
+  threadId: number | undefined,
+  allThreads: boolean,
+): DebugSessionState {
+  const threads: Record<string, DebugThreadPhase> = { ...state.threads }
+  if (allThreads) {
+    for (const id of Object.keys(threads)) threads[id] = 'running'
+  } else if (threadId !== undefined) {
+    threads[String(threadId)] = 'running'
+  }
+  return {
+    phase: phaseForThreads(threads),
+    stopEpoch: state.stopEpoch,
+    threads,
+    ...(phaseForThreads(threads) === 'stopped' ? {
+      ...(state.currentThreadId === undefined ? {} : { currentThreadId: state.currentThreadId }),
+      ...(state.stopReason === undefined ? {} : { stopReason: state.stopReason }),
+    } : {}),
+  }
+}
+
+/** Reduce the small DAP subset needed to keep agent-owned sessions in sync. */
+export function reduceDebugAdapterMessage(state: DebugSessionState, message: unknown): DebugSessionState {
+  const envelope = record(message)
+  if (envelope === undefined) return state
+
+  if (envelope.type === 'request') {
+    const command = string(envelope.command)
+    if (command === 'continue' || command === 'next' || command === 'stepIn' || command === 'stepOut' || command === 'restart') {
+      const arguments_ = record(envelope.arguments)
+      return markRunning(state, number(arguments_?.threadId), command === 'restart')
+    }
+    return state
+  }
+
+  if (envelope.type !== 'event') return state
+  const event = string(envelope.event)
+  const body = record(envelope.body)
+
+  if (event === 'initialized' || event === 'process' || event === 'thread') {
+    if (state.phase !== 'starting') return state
+    return { ...state, phase: 'running' }
+  }
+
+  if (event === 'stopped') {
+    const threadId = number(body?.threadId)
+    const stopReason = string(body?.reason)
+    const allThreadsStopped = body?.allThreadsStopped === true
+    const threads: Record<string, DebugThreadPhase> = { ...state.threads }
+    if (allThreadsStopped) {
+      for (const id of Object.keys(threads)) threads[id] = 'stopped'
+    }
+    if (threadId !== undefined) threads[String(threadId)] = 'stopped'
+    return {
+      phase: 'stopped',
+      stopEpoch: state.stopEpoch + 1,
+      threads,
+      ...(threadId === undefined ? {} : { currentThreadId: threadId }),
+      ...(stopReason === undefined ? {} : { stopReason }),
+    }
+  }
+
+  if (event === 'continued') {
+    return markRunning(state, number(body?.threadId), body?.allThreadsContinued !== false)
+  }
+
+  if (event === 'terminated' || event === 'exited') {
+    return { phase: 'terminated', stopEpoch: state.stopEpoch, threads: {} }
+  }
+
+  return state
+}

--- a/src/debug-state.ts
+++ b/src/debug-state.ts
@@ -40,13 +40,20 @@ function markRunning(
   } else if (threadId !== undefined) {
     threads[String(threadId)] = 'running'
   }
+  const phase = phaseForThreads(threads)
+  const currentThreadId = phase === 'stopped'
+    ? (state.currentThreadId !== undefined && threads[String(state.currentThreadId)] === 'stopped'
+        ? state.currentThreadId
+        : Object.entries(threads).find(([, threadPhase]) => threadPhase === 'stopped')?.[0])
+    : undefined
+  const normalizedThreadId = typeof currentThreadId === 'string' ? Number(currentThreadId) : currentThreadId
   return {
-    phase: phaseForThreads(threads),
+    phase,
     stopEpoch: state.stopEpoch,
     threads,
-    ...(phaseForThreads(threads) === 'stopped' ? {
-      ...(state.currentThreadId === undefined ? {} : { currentThreadId: state.currentThreadId }),
-      ...(state.stopReason === undefined ? {} : { stopReason: state.stopReason }),
+    ...(phase === 'stopped' ? {
+      ...(normalizedThreadId === undefined ? {} : { currentThreadId: normalizedThreadId }),
+      ...(normalizedThreadId !== state.currentThreadId || state.stopReason === undefined ? {} : { stopReason: state.stopReason }),
     } : {}),
   }
 }
@@ -56,14 +63,17 @@ export function reduceDebugAdapterMessage(state: DebugSessionState, message: unk
   const envelope = record(message)
   if (envelope === undefined) return state
 
-  if (envelope.type === 'request') {
+  if (envelope.type === 'response') {
     const command = string(envelope.command)
-    if (command === 'continue' || command === 'next' || command === 'stepIn' || command === 'stepOut' || command === 'restart') {
-      const arguments_ = record(envelope.arguments)
-      return markRunning(state, number(arguments_?.threadId), command === 'restart')
+    if (envelope.success === true
+      && (command === 'continue' || command === 'next' || command === 'stepIn' || command === 'stepOut' || command === 'restart')) {
+      const body = record(envelope.body)
+      return markRunning(state, state.currentThreadId, command === 'restart' || body?.allThreadsContinued === true)
     }
     return state
   }
+
+  if (envelope.type === 'request') return state
 
   if (envelope.type !== 'event') return state
   const event = string(envelope.event)
@@ -93,7 +103,7 @@ export function reduceDebugAdapterMessage(state: DebugSessionState, message: unk
   }
 
   if (event === 'continued') {
-    return markRunning(state, number(body?.threadId), body?.allThreadsContinued !== false)
+    return markRunning(state, number(body?.threadId), body?.allThreadsContinued === true)
   }
 
   if (event === 'terminated' || event === 'exited') {

--- a/src/debug-tools.ts
+++ b/src/debug-tools.ts
@@ -1,4 +1,5 @@
 import * as path from 'node:path'
+import { realpath } from 'node:fs/promises'
 import * as vscode from 'vscode'
 import { DebugSessionManager, type DebugSessionSnapshot } from './debug-session-manager.js'
 import { compactDebugText, debugVariableValue, launchConfigurationNames, type DebugVariableValue } from './debug-values.js'
@@ -7,14 +8,14 @@ type DebugControlAction = 'continue' | 'pause' | 'next' | 'stepIn' | 'stepOut' |
 type DebugBreakpointAction = 'add' | 'remove' | 'list'
 
 export interface DebugStartInput {
-  readonly configuration?: string
+  readonly configuration?: string | undefined
 }
 
 export interface DebugBreakpointInput {
   readonly action: DebugBreakpointAction
-  readonly path?: string
-  readonly line?: number
-  readonly breakpointId?: string
+  readonly path?: string | undefined
+  readonly line?: number | undefined
+  readonly breakpointId?: string | undefined
 }
 
 export interface DebugControlInput {
@@ -155,6 +156,11 @@ export class DebugTools implements vscode.Disposable {
     try {
       const stat = await vscode.workspace.fs.stat(uri)
       if ((stat.type & vscode.FileType.File) === 0) throw new Error('not a file')
+      const [realWorkspacePath, realFilePath] = await Promise.all([
+        realpath(this.workspace.uri.fsPath),
+        realpath(absolutePath),
+      ])
+      if (!isInside(realWorkspacePath, realFilePath)) throw new Error('outside workspace')
     } catch {
       throw new Error(`Cannot add a breakpoint because ${relativePath(this.workspace.uri.fsPath, absolutePath)} is not a file.`)
     }

--- a/src/debug-tools.ts
+++ b/src/debug-tools.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path'
 import { realpath } from 'node:fs/promises'
 import * as vscode from 'vscode'
 import { DebugSessionManager, type DebugSessionSnapshot } from './debug-session-manager.js'
-import { compactDebugText, debugVariableValue, launchConfigurationNames, type DebugVariableValue } from './debug-values.js'
+import { compactDebugText, debugVariableValue, isRuntimeInternalSource, launchConfigurationNames, type DebugVariableValue } from './debug-values.js'
 
 type DebugControlAction = 'continue' | 'pause' | 'next' | 'stepIn' | 'stepOut' | 'stop'
 type DebugBreakpointAction = 'add' | 'remove' | 'list'
@@ -23,7 +23,7 @@ export interface DebugControlInput {
 }
 
 export interface DebugStartResult {
-  readonly status: 'started' | 'selection-required'
+  readonly status: 'started' | 'completed' | 'selection-required'
   readonly configurations?: readonly string[]
   readonly session?: DebugSessionSnapshot
 }
@@ -126,7 +126,8 @@ export class DebugTools implements vscode.Disposable {
       const session = this.sessions.completeLaunch(started)
       if (!started) throw new Error(`VS Code could not start the "${configuration}" debug configuration.`)
       if (session === undefined) throw new Error('VS Code started debugging, but the session was not observed by the DeepSeek bridge.')
-      return { status: 'started', session }
+      const current = await this.sessions.waitForLaunchSettlement(500) ?? session
+      return { status: current.phase === 'terminated' ? 'completed' : 'started', session: current }
     } catch (error) {
       this.sessions.cancelLaunch()
       throw error
@@ -197,16 +198,25 @@ export class DebugTools implements vscode.Disposable {
   async context(): Promise<DebugContextResult> {
     const snapshot = this.sessions.snapshot()
     const session = this.sessions.session(snapshot?.sessionId)
-    if (snapshot === undefined || session === undefined) throw new Error('No DeepSeek debug session is active.')
+    if (snapshot === undefined || session === undefined) {
+      const latest = this.sessions.latestSnapshot()
+      if (latest?.phase === 'terminated') return { session: latest, frames: [], scopes: [], truncated: false }
+      throw new Error('No DeepSeek debug session has been launched.')
+    }
     if (snapshot.phase !== 'stopped') {
       throw new Error(`The debug session is ${snapshot.phase}; pause it or wait for a breakpoint before reading context.`)
     }
     const threadId = await this.threadId(session, snapshot)
-    const stackResponse = record(await session.customRequest('stackTrace', { threadId, startFrame: 0, levels: 8 }))
+    const stackResponse = record(await session.customRequest('stackTrace', { threadId, startFrame: 0, levels: 24 }))
     const rawFrames = Array.isArray(stackResponse?.stackFrames) ? stackResponse.stackFrames : []
+    const visibleFrames = rawFrames.filter(rawFrame => {
+      const frame = record(rawFrame)
+      const source = record(frame?.source)
+      return !isRuntimeInternalSource(nonEmptyString(source?.path))
+    })
     const frames: DebugStackFrameView[] = []
     const frameIds: number[] = []
-    for (const rawFrame of rawFrames.slice(0, 8)) {
+    for (const rawFrame of visibleFrames.slice(0, 8)) {
       const frame = record(rawFrame)
       const id = integer(frame?.id)
       const line = integer(frame?.line)
@@ -268,7 +278,7 @@ export class DebugTools implements vscode.Disposable {
       session: this.sessions.snapshot(snapshot.sessionId) ?? snapshot,
       frames,
       scopes,
-      truncated: rawFrames.length > frames.length || variableCount >= 24,
+      truncated: visibleFrames.length > frames.length || variableCount >= 24,
     }
   }
 

--- a/src/debug-tools.ts
+++ b/src/debug-tools.ts
@@ -1,0 +1,306 @@
+import * as path from 'node:path'
+import * as vscode from 'vscode'
+import { DebugSessionManager, type DebugSessionSnapshot } from './debug-session-manager.js'
+import { compactDebugText, debugVariableValue, launchConfigurationNames, type DebugVariableValue } from './debug-values.js'
+
+type DebugControlAction = 'continue' | 'pause' | 'next' | 'stepIn' | 'stepOut' | 'stop'
+type DebugBreakpointAction = 'add' | 'remove' | 'list'
+
+export interface DebugStartInput {
+  readonly configuration?: string
+}
+
+export interface DebugBreakpointInput {
+  readonly action: DebugBreakpointAction
+  readonly path?: string
+  readonly line?: number
+  readonly breakpointId?: string
+}
+
+export interface DebugControlInput {
+  readonly action: DebugControlAction
+}
+
+export interface DebugStartResult {
+  readonly status: 'started' | 'selection-required'
+  readonly configurations?: readonly string[]
+  readonly session?: DebugSessionSnapshot
+}
+
+export interface DebugBreakpointResult {
+  readonly breakpoints: readonly DebugBreakpointView[]
+}
+
+export interface DebugBreakpointView {
+  readonly id: string
+  readonly path: string
+  readonly line: number
+  readonly verified?: boolean
+}
+
+export interface DebugStackFrameView {
+  readonly id: number
+  readonly name: string
+  readonly path?: string
+  readonly line: number
+}
+
+export interface DebugScopeView {
+  readonly name: string
+  readonly variables: readonly DebugVariableValue[]
+}
+
+export interface DebugContextResult {
+  readonly session: DebugSessionSnapshot
+  readonly frames: readonly DebugStackFrameView[]
+  readonly scopes: readonly DebugScopeView[]
+  readonly truncated: boolean
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null ? value as Record<string, unknown> : undefined
+}
+
+function integer(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) ? value : undefined
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() !== '' ? value : undefined
+}
+
+function isInside(root: string, target: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(target))
+  return relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+}
+
+function relativePath(root: string, filePath: string): string {
+  const relative = path.relative(root, filePath)
+  return relative === '' ? path.basename(filePath) : relative.split(path.sep).join('/')
+}
+
+/** Implements the four small debugger operations exposed to DSH. */
+export class DebugTools implements vscode.Disposable {
+  private readonly ownedBreakpoints = new Map<string, vscode.SourceBreakpoint>()
+  private readonly breakpointChanges: vscode.Disposable
+
+  constructor(
+    private readonly sessions: DebugSessionManager,
+    private readonly workspace: vscode.WorkspaceFolder,
+  ) {
+    this.breakpointChanges = vscode.debug.onDidChangeBreakpoints(event => {
+      for (const breakpoint of event.removed) this.ownedBreakpoints.delete(breakpoint.id)
+    })
+  }
+
+  async start(input: DebugStartInput = {}): Promise<DebugStartResult> {
+    const configurations = launchConfigurationNames(
+      vscode.workspace.getConfiguration('launch', this.workspace.uri).get<unknown>('configurations'),
+    )
+    if (configurations.length === 0) {
+      throw new Error('No static debug configurations were found. Add a configuration to .vscode/launch.json first.')
+    }
+
+    const requested = input.configuration?.trim()
+    if (requested === undefined || requested === '') {
+      if (configurations.length !== 1) return { status: 'selection-required', configurations }
+    } else if (!configurations.includes(requested)) {
+      throw new Error(`Unknown debug configuration "${requested}". Available configurations: ${configurations.join(', ')}.`)
+    }
+    const configuration = requested === undefined || requested === '' ? configurations[0] : requested
+    if (configuration === undefined) throw new Error('No debug configuration is available.')
+
+    const dirty = vscode.workspace.textDocuments
+      .filter(document => document.isDirty && document.uri.scheme === 'file' && isInside(this.workspace.uri.fsPath, document.uri.fsPath))
+      .map(document => relativePath(this.workspace.uri.fsPath, document.uri.fsPath))
+    if (dirty.length > 0) {
+      throw new Error(`Save or discard unsaved changes before debugging: ${dirty.join(', ')}.`)
+    }
+
+    this.sessions.beginLaunch(this.workspace)
+    try {
+      const started = await vscode.debug.startDebugging(this.workspace, configuration, {
+        suppressSaveBeforeStart: true,
+      })
+      const session = this.sessions.completeLaunch(started)
+      if (!started) throw new Error(`VS Code could not start the "${configuration}" debug configuration.`)
+      if (session === undefined) throw new Error('VS Code started debugging, but the session was not observed by the DeepSeek bridge.')
+      return { status: 'started', session }
+    } catch (error) {
+      this.sessions.cancelLaunch()
+      throw error
+    }
+  }
+
+  async breakpoint(input: DebugBreakpointInput): Promise<DebugBreakpointResult> {
+    if (input.action === 'list') return await this.listBreakpoints()
+    if (input.action === 'remove') {
+      const breakpointId = input.breakpointId?.trim()
+      if (breakpointId === undefined || breakpointId === '') throw new Error('breakpointId is required when removing a breakpoint.')
+      const breakpoint = this.ownedBreakpoints.get(breakpointId)
+      if (breakpoint === undefined) throw new Error('That breakpoint is not owned by the DeepSeek debug bridge.')
+      vscode.debug.removeBreakpoints([breakpoint])
+      this.ownedBreakpoints.delete(breakpointId)
+      return await this.listBreakpoints()
+    }
+
+    const filePath = input.path?.trim()
+    if (filePath === undefined || filePath === '') throw new Error('path is required when adding a breakpoint.')
+    if (input.line === undefined || !Number.isInteger(input.line) || input.line < 1) {
+      throw new Error('line must be a positive, 1-based line number.')
+    }
+    const absolutePath = path.resolve(this.workspace.uri.fsPath, filePath)
+    if (!isInside(this.workspace.uri.fsPath, absolutePath)) throw new Error('Breakpoints must stay inside the current workspace.')
+    const uri = vscode.Uri.file(absolutePath)
+    try {
+      const stat = await vscode.workspace.fs.stat(uri)
+      if ((stat.type & vscode.FileType.File) === 0) throw new Error('not a file')
+    } catch {
+      throw new Error(`Cannot add a breakpoint because ${relativePath(this.workspace.uri.fsPath, absolutePath)} is not a file.`)
+    }
+    const breakpoint = new vscode.SourceBreakpoint(
+      new vscode.Location(uri, new vscode.Position(input.line - 1, 0)),
+    )
+    vscode.debug.addBreakpoints([breakpoint])
+    this.ownedBreakpoints.set(breakpoint.id, breakpoint)
+    return await this.listBreakpoints()
+  }
+
+  async control(input: DebugControlInput): Promise<DebugSessionSnapshot> {
+    const snapshot = this.sessions.snapshot()
+    const session = this.sessions.session(snapshot?.sessionId)
+    if (snapshot === undefined || session === undefined) throw new Error('No DeepSeek debug session is active.')
+
+    if (input.action === 'stop') {
+      await vscode.debug.stopDebugging(session)
+      return await this.sessions.waitFor(snapshot.sessionId, ['terminated'], 3_000)
+    }
+
+    const threadId = await this.threadId(session, snapshot)
+    if (input.action !== 'pause' && snapshot.phase !== 'stopped') {
+      throw new Error(`Cannot ${input.action} while the debug session is ${snapshot.phase}.`)
+    }
+    if (input.action === 'pause' && snapshot.phase === 'stopped') return snapshot
+
+    const command = input.action
+    await session.customRequest(command, { threadId })
+    const wanted = input.action === 'continue' ? ['stopped', 'terminated'] as const : ['stopped', 'terminated'] as const
+    return await this.sessions.waitFor(snapshot.sessionId, wanted, 3_000)
+  }
+
+  async context(): Promise<DebugContextResult> {
+    const snapshot = this.sessions.snapshot()
+    const session = this.sessions.session(snapshot?.sessionId)
+    if (snapshot === undefined || session === undefined) throw new Error('No DeepSeek debug session is active.')
+    if (snapshot.phase !== 'stopped') {
+      throw new Error(`The debug session is ${snapshot.phase}; pause it or wait for a breakpoint before reading context.`)
+    }
+    const threadId = await this.threadId(session, snapshot)
+    const stackResponse = record(await session.customRequest('stackTrace', { threadId, startFrame: 0, levels: 8 }))
+    const rawFrames = Array.isArray(stackResponse?.stackFrames) ? stackResponse.stackFrames : []
+    const frames: DebugStackFrameView[] = []
+    const frameIds: number[] = []
+    for (const rawFrame of rawFrames.slice(0, 8)) {
+      const frame = record(rawFrame)
+      const id = integer(frame?.id)
+      const line = integer(frame?.line)
+      if (id === undefined || line === undefined) continue
+      const source = record(frame?.source)
+      const sourcePath = nonEmptyString(source?.path)
+      frames.push({
+        id,
+        name: compactDebugText(nonEmptyString(frame?.name) ?? '<anonymous>', 160),
+        ...(sourcePath === undefined ? {} : {
+          path: isInside(this.workspace.uri.fsPath, sourcePath)
+            ? relativePath(this.workspace.uri.fsPath, sourcePath)
+            : compactDebugText(sourcePath, 240),
+        }),
+        line,
+      })
+      frameIds.push(id)
+    }
+    const frameId = frameIds[0]
+    if (frameId === undefined) return { session: snapshot, frames, scopes: [], truncated: false }
+
+    const scopesResponse = record(await session.customRequest('scopes', { frameId }))
+    const rawScopes = Array.isArray(scopesResponse?.scopes) ? scopesResponse.scopes : []
+    const availableScopes = rawScopes
+      .map(record)
+      .filter((scope): scope is Record<string, unknown> => scope !== undefined && scope.expensive !== true)
+    const localScopes = availableScopes.filter(scope => /local|argument|closure|block/i.test(nonEmptyString(scope.name) ?? ''))
+    const preferredScopes = (localScopes.length > 0 ? localScopes : availableScopes).slice(0, 2)
+    const scopes: DebugScopeView[] = []
+    let variableCount = 0
+    for (const scope of preferredScopes) {
+      const variablesReference = integer(scope.variablesReference)
+      if (variablesReference === undefined || variablesReference <= 0) continue
+      const variablesResponse = record(await session.customRequest('variables', {
+        variablesReference,
+        start: 0,
+        count: Math.max(0, 24 - variableCount),
+      }))
+      const rawVariables = Array.isArray(variablesResponse?.variables) ? variablesResponse.variables : []
+      const variables: DebugVariableValue[] = []
+      for (const rawVariable of rawVariables.slice(0, Math.max(0, 24 - variableCount))) {
+        const variable = record(rawVariable)
+        const name = nonEmptyString(variable?.name)
+        const value = typeof variable?.value === 'string' ? variable.value : undefined
+        if (name === undefined || value === undefined) continue
+        variables.push(debugVariableValue(
+          name,
+          value,
+          nonEmptyString(variable?.type),
+          integer(variable?.variablesReference) ?? 0,
+        ))
+        variableCount += 1
+      }
+      scopes.push({ name: compactDebugText(nonEmptyString(scope.name) ?? 'Locals', 120), variables })
+      if (variableCount >= 24) break
+    }
+
+    return {
+      session: this.sessions.snapshot(snapshot.sessionId) ?? snapshot,
+      frames,
+      scopes,
+      truncated: rawFrames.length > frames.length || variableCount >= 24,
+    }
+  }
+
+  private async listBreakpoints(): Promise<DebugBreakpointResult> {
+    const session = this.sessions.session()
+    const views: DebugBreakpointView[] = []
+    for (const breakpoint of this.ownedBreakpoints.values()) {
+      let verified: boolean | undefined
+      if (session !== undefined) {
+        try {
+          const protocolBreakpoint = record(await session.getDebugProtocolBreakpoint(breakpoint))
+          verified = typeof protocolBreakpoint?.verified === 'boolean' ? protocolBreakpoint.verified : undefined
+        } catch {
+          verified = undefined
+        }
+      }
+      views.push({
+        id: breakpoint.id,
+        path: relativePath(this.workspace.uri.fsPath, breakpoint.location.uri.fsPath),
+        line: breakpoint.location.range.start.line + 1,
+        ...(verified === undefined ? {} : { verified }),
+      })
+    }
+    return { breakpoints: views }
+  }
+
+  private async threadId(session: vscode.DebugSession, snapshot: DebugSessionSnapshot): Promise<number> {
+    if (snapshot.currentThreadId !== undefined) return snapshot.currentThreadId
+    const response = record(await session.customRequest('threads'))
+    const threads = Array.isArray(response?.threads) ? response.threads : []
+    const threadId = integer(record(threads[0])?.id)
+    if (threadId === undefined) throw new Error('The debug adapter did not report an available thread.')
+    return threadId
+  }
+
+  dispose(): void {
+    this.breakpointChanges.dispose()
+    if (this.ownedBreakpoints.size > 0) vscode.debug.removeBreakpoints([...this.ownedBreakpoints.values()])
+    this.ownedBreakpoints.clear()
+  }
+}

--- a/src/debug-values.ts
+++ b/src/debug-values.ts
@@ -12,6 +12,14 @@ export function compactDebugText(value: string, maxChars = 240): string {
   return normalized.length <= maxChars ? normalized : `${normalized.slice(0, Math.max(0, maxChars - 1))}…`
 }
 
+export function isRuntimeInternalSource(value: string | undefined): boolean {
+  if (value === undefined) return false
+  const normalized = value.replace(/\\/g, '/').toLowerCase()
+  return normalized.startsWith('<node_internals>/')
+    || normalized.startsWith('node:internal/')
+    || normalized.includes('/node:internal/')
+}
+
 export function debugVariableValue(
   name: string,
   value: string,

--- a/src/debug-values.ts
+++ b/src/debug-values.ts
@@ -1,0 +1,43 @@
+const SENSITIVE_NAME = /(?:api[_-]?key|access[_-]?token|authorization|auth[_-]?token|cookie|credential|password|passwd|secret|session[_-]?token)/i
+
+export interface DebugVariableValue {
+  readonly name: string
+  readonly value: string
+  readonly type?: string
+  readonly expandable: boolean
+}
+
+export function compactDebugText(value: string, maxChars = 240): string {
+  const normalized = value.replace(/[\r\n\t]+/g, ' ').replace(/\s{2,}/g, ' ').trim()
+  return normalized.length <= maxChars ? normalized : `${normalized.slice(0, Math.max(0, maxChars - 1))}…`
+}
+
+export function debugVariableValue(
+  name: string,
+  value: string,
+  type: string | undefined,
+  variablesReference: number,
+): DebugVariableValue {
+  return {
+    name: compactDebugText(name, 120),
+    value: SENSITIVE_NAME.test(name) ? '<redacted>' : compactDebugText(value),
+    ...(type === undefined || type.trim() === '' ? {} : { type: compactDebugText(type, 120) }),
+    expandable: variablesReference > 0,
+  }
+}
+
+export function launchConfigurationNames(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  const names = new Set<string>()
+  for (const item of value) {
+    if (typeof item !== 'object' || item === null) continue
+    const name = (item as Record<string, unknown>).name
+    const type = (item as Record<string, unknown>).type
+    const request = (item as Record<string, unknown>).request
+    if (typeof name !== 'string' || name.trim() === '') continue
+    if (typeof type !== 'string' || type.trim() === '') continue
+    if (request !== 'launch' && request !== 'attach') continue
+    names.add(name.trim())
+  }
+  return [...names]
+}

--- a/src/debug-workspace.ts
+++ b/src/debug-workspace.ts
@@ -1,0 +1,10 @@
+import * as path from 'node:path'
+import type * as vscode from 'vscode'
+
+export function debugWorkspaceForPath(
+  folders: readonly vscode.WorkspaceFolder[],
+  workspacePath: string,
+): vscode.WorkspaceFolder | undefined {
+  const expected = path.resolve(workspacePath)
+  return folders.find(folder => path.resolve(folder.uri.fsPath) === expected)
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1606,6 +1606,45 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(vscode.commands.registerCommand('deepseekHarness.restart', async () => {
     await controller.restart().catch(error => { void vscode.window.showErrorMessage(error instanceof Error ? error.message : String(error)) })
   }))
+  if (workspace !== undefined) {
+    let autonomousDebugging = vscode.workspace
+      .getConfiguration('deepseekHarness', workspace.uri)
+      .get<boolean>('autonomousDebugging', false)
+    let debugRestartTimer: NodeJS.Timeout | undefined
+    let debugRestartTask = Promise.resolve()
+    context.subscriptions.push(
+      vscode.workspace.onDidChangeConfiguration(event => {
+        if (!event.affectsConfiguration('deepseekHarness.autonomousDebugging', workspace.uri)) return
+        const enabled = vscode.workspace
+          .getConfiguration('deepseekHarness', workspace.uri)
+          .get<boolean>('autonomousDebugging', false)
+        if (enabled === autonomousDebugging) return
+        autonomousDebugging = enabled
+
+        if (debugRestartTimer !== undefined) clearTimeout(debugRestartTimer)
+        debugRestartTimer = setTimeout(() => {
+          debugRestartTimer = undefined
+          if (runtime.state.kind === 'stopped') {
+            output.appendLine(`[debug] Autonomous debugging ${enabled ? 'enabled' : 'disabled'}; it will apply the next time DSH starts.`)
+            return
+          }
+          debugRestartTask = debugRestartTask
+            .catch(() => undefined)
+            .then(async () => {
+              output.appendLine(`[debug] Autonomous debugging ${enabled ? 'enabled' : 'disabled'}; restarting DSH to apply the change.`)
+              await controller.restart()
+              void vscode.window.showInformationMessage(`VS Code debugging ${enabled ? 'enabled' : 'disabled'}. DeepSeek Harness restarted.`)
+            })
+            .catch(error => {
+              const message = error instanceof Error ? error.message : String(error)
+              output.appendLine(`[debug] Failed to restart DSH after the setting changed: ${message}`)
+              void vscode.window.showErrorMessage(`Could not apply the VS Code debugging setting: ${message}`)
+            })
+        }, 200)
+      }),
+      { dispose: () => { if (debugRestartTimer !== undefined) clearTimeout(debugRestartTimer) } },
+    )
+  }
   context.subscriptions.push(vscode.commands.registerCommand('deepseekHarness.managePlugins', async () => {
     await pluginManager.show().catch(error => {
       const message = error instanceof Error ? error.message : String(error)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,6 @@ import { DEEPSEEK_API_KEY_SECRET, normalizeDeepSeekApiKey } from './credentials.
 import { DiffReviewManager, type ChangedFileGroup } from './diff-review.js'
 import { DebugRuntimeContribution } from './debug-runtime-contribution.js'
 import { DebugSessionManager } from './debug-session-manager.js'
-import { DebugTools } from './debug-tools.js'
 import { DirtyFileGuard } from './dirty-file-guard.js'
 import { EditorContextBridge } from './editor-context-bridge.js'
 import {
@@ -1549,12 +1548,9 @@ export function activate(context: vscode.ExtensionContext): void {
   const workspace = vscode.workspace.workspaceFolders?.[0]
   const output = vscode.window.createOutputChannel('DeepSeek Harness', { log: true })
   const debugSessions = workspace === undefined ? undefined : new DebugSessionManager()
-  const debugTools = workspace === undefined || debugSessions === undefined
+  const debugRuntime = workspace === undefined || debugSessions === undefined
     ? undefined
-    : new DebugTools(debugSessions, workspace)
-  const debugRuntime = workspace === undefined || debugTools === undefined
-    ? undefined
-    : new DebugRuntimeContribution(context, workspace, debugTools, output)
+    : new DebugRuntimeContribution(context, debugSessions, output)
   const runtime = new DshRuntime(context, output, debugRuntime)
   activeRuntime = runtime
 
@@ -1576,7 +1572,6 @@ export function activate(context: vscode.ExtensionContext): void {
     diffReviews,
     editorContext,
     provider,
-    ...(debugTools === undefined ? [] : [debugTools]),
     ...(debugSessions === undefined ? [] : [debugSessions]),
   )
   context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('dsh-diff', diffReviews))
@@ -1607,19 +1602,15 @@ export function activate(context: vscode.ExtensionContext): void {
     await controller.restart().catch(error => { void vscode.window.showErrorMessage(error instanceof Error ? error.message : String(error)) })
   }))
   if (workspace !== undefined) {
-    let autonomousDebugging = vscode.workspace
-      .getConfiguration('deepseekHarness', workspace.uri)
-      .get<boolean>('autonomousDebugging', false)
     let debugRestartTimer: NodeJS.Timeout | undefined
     let debugRestartTask = Promise.resolve()
     context.subscriptions.push(
       vscode.workspace.onDidChangeConfiguration(event => {
-        if (!event.affectsConfiguration('deepseekHarness.autonomousDebugging', workspace.uri)) return
+        const currentWorkspace = controller.cwd === '' ? workspace.uri : vscode.Uri.file(controller.cwd)
+        if (!event.affectsConfiguration('deepseekHarness.autonomousDebugging', currentWorkspace)) return
         const enabled = vscode.workspace
-          .getConfiguration('deepseekHarness', workspace.uri)
+          .getConfiguration('deepseekHarness', currentWorkspace)
           .get<boolean>('autonomousDebugging', false)
-        if (enabled === autonomousDebugging) return
-        autonomousDebugging = enabled
 
         if (debugRestartTimer !== undefined) clearTimeout(debugRestartTimer)
         debugRestartTimer = setTimeout(() => {
@@ -1690,7 +1681,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(vscode.commands.registerCommand('deepseekHarness.showOutput', () => { output.show(true) }))
   context.subscriptions.push(vscode.commands.registerCommand('deepseekHarness.openInBrowser', async () => {
     try {
-      const uri = await runtime.start()
+      const uri = await runtime.start(controller.cwd === '' ? undefined : vscode.Uri.file(controller.cwd))
       await vscode.env.openExternal(await vscode.env.asExternalUri(uri))
     } catch (error) {
       void vscode.window.showErrorMessage(error instanceof Error ? error.message : String(error))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,6 +20,9 @@ import {
 } from './collaboration-state.js'
 import { DEEPSEEK_API_KEY_SECRET, normalizeDeepSeekApiKey } from './credentials.js'
 import { DiffReviewManager, type ChangedFileGroup } from './diff-review.js'
+import { DebugRuntimeContribution } from './debug-runtime-contribution.js'
+import { DebugSessionManager } from './debug-session-manager.js'
+import { DebugTools } from './debug-tools.js'
 import { DirtyFileGuard } from './dirty-file-guard.js'
 import { EditorContextBridge } from './editor-context-bridge.js'
 import {
@@ -1545,7 +1548,14 @@ async function chooseProblem(editorContext: EditorContextBridge, args: readonly 
 export function activate(context: vscode.ExtensionContext): void {
   const workspace = vscode.workspace.workspaceFolders?.[0]
   const output = vscode.window.createOutputChannel('DeepSeek Harness', { log: true })
-  const runtime = new DshRuntime(context, output)
+  const debugSessions = workspace === undefined ? undefined : new DebugSessionManager()
+  const debugTools = workspace === undefined || debugSessions === undefined
+    ? undefined
+    : new DebugTools(debugSessions, workspace)
+  const debugRuntime = workspace === undefined || debugTools === undefined
+    ? undefined
+    : new DebugRuntimeContribution(context, workspace, debugTools, output)
+  const runtime = new DshRuntime(context, output, debugRuntime)
   activeRuntime = runtime
 
   if (workspace === undefined) {
@@ -1559,7 +1569,16 @@ export function activate(context: vscode.ExtensionContext): void {
   const provider = new DshViewProvider(controller, output, editorContext, context.extensionUri)
   const panels = new Set<{ panel: vscode.WebviewPanel; surface: DshSurface }>()
 
-  context.subscriptions.push(output, runtime, controller, diffReviews, editorContext, provider)
+  context.subscriptions.push(
+    output,
+    runtime,
+    controller,
+    diffReviews,
+    editorContext,
+    provider,
+    ...(debugTools === undefined ? [] : [debugTools]),
+    ...(debugSessions === undefined ? [] : [debugSessions]),
+  )
   context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider('dsh-diff', diffReviews))
   context.subscriptions.push(runtime.onDidChangeState(state => { controller.observeRuntime(state) }))
   context.subscriptions.push(vscode.window.registerWebviewViewProvider(

--- a/src/runtime-launch.ts
+++ b/src/runtime-launch.ts
@@ -1,0 +1,29 @@
+export interface RuntimeLaunchContext {
+  readonly workspacePath: string
+  readonly configuredExecutable: string
+  readonly configuredArguments: readonly string[]
+}
+
+/**
+ * One managed-runtime launch overlay. Returning a preparation opts out of
+ * external runtime reuse for that launch.
+ */
+export interface RuntimeLaunchPreparation {
+  transformArguments(args: readonly string[], dshVersion: string | undefined): readonly string[]
+  readonly environment?: Readonly<Record<string, string>>
+  dispose?(): void | Promise<void>
+}
+
+export interface RuntimeLaunchContributor {
+  prepare(context: RuntimeLaunchContext): Promise<RuntimeLaunchPreparation | undefined>
+}
+
+export function applyRuntimeLaunchPreparation(
+  args: readonly string[],
+  dshVersion: string | undefined,
+  preparation: RuntimeLaunchPreparation | undefined,
+): string[] {
+  return preparation === undefined
+    ? [...args]
+    : [...preparation.transformArguments(args, dshVersion)]
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -8,6 +8,11 @@ import {
   probeDshServer,
   shouldProbeExistingDsh,
 } from './runtime-endpoint.js'
+import {
+  applyRuntimeLaunchPreparation,
+  type RuntimeLaunchContributor,
+  type RuntimeLaunchPreparation,
+} from './runtime-launch.js'
 
 export type RuntimeOwnership = 'external' | 'managed'
 
@@ -79,6 +84,7 @@ export class DshRuntime implements vscode.Disposable {
   private startupTimer: NodeJS.Timeout | undefined
   private stdoutBuffer = ''
   private stopping = false
+  private launchPreparation: RuntimeLaunchPreparation | undefined
   private _state: RuntimeState = { kind: 'stopped' }
 
   readonly onDidChangeState = this.changes.event
@@ -86,6 +92,7 @@ export class DshRuntime implements vscode.Disposable {
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly output: vscode.OutputChannel,
+    private readonly launchContributor?: RuntimeLaunchContributor,
   ) {}
 
   get state(): RuntimeState {
@@ -129,9 +136,21 @@ export class DshRuntime implements vscode.Disposable {
     let version: string | undefined
     let storedApiKey: string | undefined
     try {
+      const launchPreparation = await this.launchContributor?.prepare({
+        workspacePath: workspace.fsPath,
+        configuredExecutable,
+        configuredArguments: configuredArgs,
+      })
+      if (this.pending !== pending) {
+        await launchPreparation?.dispose?.()
+        return pending.promise
+      }
+      this.launchPreparation = launchPreparation
+
       // A nested deepseek-harness checkout is the documented empty-executable
       // launch; an unrelated stock DSH on 3080 must not silently pre-empt it.
-      if (shouldProbeExistingDsh(reuseExistingRuntime, configuredExecutable, hasCustomArguments)
+      if (launchPreparation === undefined
+        && shouldProbeExistingDsh(reuseExistingRuntime, configuredExecutable, hasCustomArguments)
         && findSourceRoot(this.context.extensionUri.fsPath) === undefined) {
         const existingUrl = new URL(DEFAULT_DSH_SERVER_URL)
         this.publish({ kind: 'starting', detail: 'Looking for an existing DeepSeek Harness runtime…' })
@@ -151,7 +170,8 @@ export class DshRuntime implements vscode.Disposable {
       })
       version = await readDshVersion(versionLaunch, workspace.fsPath)
       if (this.pending !== pending) return pending.promise
-      const args = webArgsForDshVersion(configuredArgs, version)
+      const versionedArgs = webArgsForDshVersion(configuredArgs, version)
+      const args = applyRuntimeLaunchPreparation(versionedArgs, version, launchPreparation)
       launch = resolveLaunch(this.context.extensionUri.fsPath, configuredExecutable, args, {
         cwd: workspace.fsPath,
       })
@@ -181,6 +201,7 @@ export class DshRuntime implements vscode.Disposable {
           NO_COLOR: '1',
           ...(storedApiKey === undefined ? {} : { DEEPSEEK_API_KEY: storedApiKey }),
           ...launch.env,
+          ...this.launchPreparation?.environment,
         },
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
@@ -202,6 +223,7 @@ export class DshRuntime implements vscode.Disposable {
     child.on('exit', (code, signal) => {
       this.clearStartupTimer()
       this.child = undefined
+      void this.releaseLaunchPreparation()
       const detail = `DSH exited (${signal ?? `code ${String(code)}`}).`
       this.output.appendLine(`[runtime] ${detail}`)
       if (this.stopping) {
@@ -252,7 +274,18 @@ export class DshRuntime implements vscode.Disposable {
     this.pending = undefined
     this.clearStartupTimer()
     this.publish({ kind: 'failed', message: error.message })
+    void this.releaseLaunchPreparation()
     pending.reject(error)
+  }
+
+  private async releaseLaunchPreparation(): Promise<void> {
+    const preparation = this.launchPreparation
+    this.launchPreparation = undefined
+    try {
+      await preparation?.dispose?.()
+    } catch (error) {
+      this.output.appendLine(`[runtime] launch contribution cleanup failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
   }
 
   private clearStartupTimer(): void {
@@ -275,6 +308,7 @@ export class DshRuntime implements vscode.Disposable {
     this.pending = undefined
     pending?.reject(new Error('DSH runtime stopped.'))
     if (child === undefined || child.exitCode !== null) {
+      await this.releaseLaunchPreparation()
       this.publish({ kind: 'stopped' })
       return
     }
@@ -295,6 +329,7 @@ export class DshRuntime implements vscode.Disposable {
       }, 4_000)
       if (!child.kill('SIGTERM')) finish()
     })
+    await this.releaseLaunchPreparation()
     this.publish({ kind: 'stopped' })
   }
 

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -85,6 +85,7 @@ export class DshRuntime implements vscode.Disposable {
   private stdoutBuffer = ''
   private stopping = false
   private launchPreparation: RuntimeLaunchPreparation | undefined
+  private launchPreparationRelease: Promise<void> | undefined
   private _state: RuntimeState = { kind: 'stopped' }
 
   readonly onDidChangeState = this.changes.event
@@ -108,6 +109,7 @@ export class DshRuntime implements vscode.Disposable {
     if (this._state.kind === 'ready') return this._state.localUri
     if (this.pending !== undefined) return this.pending.promise
     if (this.child !== undefined) await this.stop()
+    await this.releaseLaunchPreparation()
 
     const workspace = workspaceUri === undefined
       ? vscode.workspace.workspaceFolders?.[0]?.uri
@@ -279,12 +281,26 @@ export class DshRuntime implements vscode.Disposable {
   }
 
   private async releaseLaunchPreparation(): Promise<void> {
+    if (this.launchPreparationRelease !== undefined) {
+      await this.launchPreparationRelease
+      return
+    }
     const preparation = this.launchPreparation
     this.launchPreparation = undefined
+    if (preparation === undefined) return
+
+    const release = (async () => {
+      try {
+        await preparation.dispose?.()
+      } catch (error) {
+        this.output.appendLine(`[runtime] launch contribution cleanup failed: ${error instanceof Error ? error.message : String(error)}`)
+      }
+    })()
+    this.launchPreparationRelease = release
     try {
-      await preparation?.dispose?.()
-    } catch (error) {
-      this.output.appendLine(`[runtime] launch contribution cleanup failed: ${error instanceof Error ? error.message : String(error)}`)
+      await release
+    } finally {
+      if (this.launchPreparationRelease === release) this.launchPreparationRelease = undefined
     }
   }
 

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -47,7 +47,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     .job-duration { grid-column: 3; grid-row: 1 / 3; align-self: center; color: var(--vscode-descriptionForeground); font: 10px var(--vscode-editor-font-family); }
     .icon-button:focus-visible, select:focus-visible, textarea:focus-visible, input:focus-visible, button:focus-visible { outline: 1px solid var(--vscode-focusBorder); outline-offset: -1px; }
     svg { width: 17px; height: 17px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
-    .scroll { min-width: 0; min-height: 0; overflow-x: hidden; overflow-y: auto; scrollbar-color: var(--vscode-scrollbarSlider-background) transparent; }
+    .scroll { min-width: 0; min-height: 0; overflow-x: hidden; overflow-y: auto; overflow-anchor: none; scrollbar-color: var(--vscode-scrollbarSlider-background) transparent; }
     .conversation { width: 100%; min-width: 0; max-width: 760px; margin: 0 auto; padding: 12px 14px 30px; overflow: hidden; }
     .conversation-slot, .messages { display: contents; }
     .history-loader { display: flex; justify-content: center; padding: 1px 0 9px; }
@@ -309,6 +309,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let historyAnchor;
     let renderFrame;
     let pendingRenderState;
+    let followConversationTail = true;
+    let tailScrollFrame;
     let renderedSessionId;
     let renderedStatusKey = '';
     let renderedHistoryKey = '';
@@ -323,6 +325,22 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     const pendingMessageAppends = new Map();
     let toolOutputRequestId = 0;
     const toolOutputChunkSize = 20000;
+
+    function conversationNearBottom() {
+      return elements.scroll.scrollHeight - elements.scroll.scrollTop - elements.scroll.clientHeight < 80;
+    }
+    function scheduleTailScroll(force) {
+      if (force) followConversationTail = true;
+      if ((!followConversationTail && !force) || historyAnchor || tailScrollFrame !== undefined) return;
+      tailScrollFrame = requestAnimationFrame(() => {
+        tailScrollFrame = undefined;
+        if (!historyAnchor && followConversationTail) elements.scroll.scrollTop = elements.scroll.scrollHeight;
+      });
+    }
+    elements.scroll.addEventListener('scroll', () => { followConversationTail = conversationNearBottom(); }, { passive: true });
+    const conversationResizeObserver = new ResizeObserver(() => scheduleTailScroll(false));
+    conversationResizeObserver.observe(elements.conversation);
+    conversationResizeObserver.observe(elements.scroll);
 
     function node(tag, className, text) {
       const value = document.createElement(tag);
@@ -1292,6 +1310,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function renderConversation(current) {
       if (renderedSessionId !== current.sessionId) {
         renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
+        followConversationTail = true;
         renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear();
         for (const request of loadingToolRequests.values()) clearTimeout(request.timer);
         loadingToolRequests.clear(); toolOutputErrors.clear(); toolOutputPages.clear(); deferredOutputViews.clear(); pendingMessageAppends.clear();
@@ -1328,7 +1347,6 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       }
     }
     function render(current) {
-      const nearBottom = elements.scroll.scrollHeight - elements.scroll.scrollTop - elements.scroll.clientHeight < 80;
       const preservingHistory = historyAnchor && historyAnchor.sessionId === current.sessionId;
       state = current;
       if (renderedChrome.workspaceName !== current.workspaceName || renderedChrome.cwd !== current.cwd) {
@@ -1363,7 +1381,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (preservingHistory && current.loadingHistory !== true) {
         const anchor = historyAnchor; historyAnchor = undefined;
         requestAnimationFrame(() => { elements.scroll.scrollTop = anchor.top + elements.scroll.scrollHeight - anchor.height; });
-      } else if (!preservingHistory && (nearBottom || current.approval || current.question)) requestAnimationFrame(() => { elements.scroll.scrollTop = elements.scroll.scrollHeight; });
+      } else if (!preservingHistory) scheduleTailScroll(Boolean(current.approval || current.question));
     }
     function scheduleRender(current) {
       state = current; pendingRenderState = current;

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -337,7 +337,35 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         if (!historyAnchor && followConversationTail) elements.scroll.scrollTop = elements.scroll.scrollHeight;
       });
     }
-    elements.scroll.addEventListener('scroll', () => { followConversationTail = conversationNearBottom(); }, { passive: true });
+    function detachConversationTail() {
+      followConversationTail = false;
+      if (tailScrollFrame !== undefined) {
+        cancelAnimationFrame(tailScrollFrame);
+        tailScrollFrame = undefined;
+      }
+    }
+    function followConversationTailIfReached() {
+      if (!conversationNearBottom()) return;
+      followConversationTail = true;
+      scheduleTailScroll(false);
+    }
+    elements.scroll.addEventListener('wheel', event => {
+      if (event.deltaY < 0) detachConversationTail();
+      else if (event.deltaY > 0) requestAnimationFrame(followConversationTailIfReached);
+    }, { passive: true });
+    elements.scroll.addEventListener('pointerdown', event => {
+      const bounds = elements.scroll.getBoundingClientRect();
+      const scrollbarWidth = Math.max(16, elements.scroll.offsetWidth - elements.scroll.clientWidth);
+      if (event.clientX < bounds.right - scrollbarWidth) return;
+      detachConversationTail();
+      const finish = () => {
+        window.removeEventListener('pointerup', finish);
+        window.removeEventListener('pointercancel', finish);
+        followConversationTailIfReached();
+      };
+      window.addEventListener('pointerup', finish);
+      window.addEventListener('pointercancel', finish);
+    }, { passive: true });
     const conversationResizeObserver = new ResizeObserver(() => scheduleTailScroll(false));
     conversationResizeObserver.observe(elements.conversation);
     conversationResizeObserver.observe(elements.scroll);
@@ -801,7 +829,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (rendered) deferredOutputViews.delete(message.id);
       pendingMessageAppends.delete(message.id);
       const next = renderMessage(message);
-      if (rendered && rendered.node.isConnected) rendered.node.replaceWith(next.node);
+      // reconcileMessages owns node placement. Replacing a connected node here
+      // invalidates its cursor before insertBefore can finish reconciling the list.
       renderedMessages.set(message.id, next);
       return next.node;
     }

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1361,7 +1361,13 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         renderedHistoryKey = historyKey; elements.conversationHistory.replaceChildren();
         if (current.hasMoreHistory || current.loadingHistory) {
           const loader = node('div', 'history-loader'); const button = node('button', 'history-button', current.loadingHistory ? 'Loading earlier messages…' : 'Load earlier messages'); button.type = 'button'; button.disabled = current.loadingHistory === true;
-          button.addEventListener('click', () => { historyAnchor = { sessionId: current.sessionId, height: elements.scroll.scrollHeight, top: elements.scroll.scrollTop }; button.disabled = true; button.textContent = 'Loading earlier messages…'; vscode.postMessage({ type: 'load-history' }); }); loader.append(button); elements.conversationHistory.append(loader);
+          button.addEventListener('click', () => {
+            detachConversationTail();
+            historyAnchor = { sessionId: current.sessionId, height: elements.scroll.scrollHeight, top: elements.scroll.scrollTop };
+            button.disabled = true; button.textContent = 'Loading earlier messages…';
+            vscode.postMessage({ type: 'load-history' });
+          });
+          loader.append(button); elements.conversationHistory.append(loader);
         }
       }
       reconcileMessages(array(current.messages), current);

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -344,28 +344,12 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         tailScrollFrame = undefined;
       }
     }
-    function followConversationTailIfReached() {
-      if (!conversationNearBottom()) return;
-      followConversationTail = true;
-      scheduleTailScroll(false);
+    function synchronizeConversationTail() {
+      if (historyAnchor) return;
+      if (conversationNearBottom()) followConversationTail = true;
+      else detachConversationTail();
     }
-    elements.scroll.addEventListener('wheel', event => {
-      if (event.deltaY < 0) detachConversationTail();
-      else if (event.deltaY > 0) requestAnimationFrame(followConversationTailIfReached);
-    }, { passive: true });
-    elements.scroll.addEventListener('pointerdown', event => {
-      const bounds = elements.scroll.getBoundingClientRect();
-      const scrollbarWidth = Math.max(16, elements.scroll.offsetWidth - elements.scroll.clientWidth);
-      if (event.clientX < bounds.right - scrollbarWidth) return;
-      detachConversationTail();
-      const finish = () => {
-        window.removeEventListener('pointerup', finish);
-        window.removeEventListener('pointercancel', finish);
-        followConversationTailIfReached();
-      };
-      window.addEventListener('pointerup', finish);
-      window.addEventListener('pointercancel', finish);
-    }, { passive: true });
+    elements.scroll.addEventListener('scroll', synchronizeConversationTail, { passive: true });
     const conversationResizeObserver = new ResizeObserver(() => scheduleTailScroll(false));
     conversationResizeObserver.observe(elements.conversation);
     conversationResizeObserver.observe(elements.scroll);

--- a/tests/debug-mcp-server.spec.ts
+++ b/tests/debug-mcp-server.spec.ts
@@ -1,0 +1,78 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { DebugMcpServer, type DebugToolHandler } from '../src/debug-mcp-server.ts'
+
+const servers: DebugMcpServer[] = []
+
+function fakeTools(): DebugToolHandler {
+  return {
+    start: vi.fn(async () => ({ status: 'selection-required', configurations: ['Launch app'] })),
+    breakpoint: vi.fn(async () => ({ breakpoints: [] })),
+    control: vi.fn(async () => ({
+      sessionId: 'session-1',
+      name: 'Launch app',
+      type: 'node',
+      phase: 'running',
+      stopEpoch: 0,
+      threads: {},
+    })),
+    context: vi.fn(async () => ({
+      session: {
+        sessionId: 'session-1',
+        name: 'Launch app',
+        type: 'node',
+        phase: 'stopped',
+        stopEpoch: 1,
+        threads: { 1: 'stopped' },
+        currentThreadId: 1,
+      },
+      frames: [],
+      scopes: [],
+      truncated: false,
+    })),
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(async server => { await server.dispose() }))
+})
+
+describe('debug MCP server', () => {
+  it('requires its runtime token and exposes only the four debugger tools', async () => {
+    const tools = fakeTools()
+    const server = new DebugMcpServer(tools)
+    servers.push(server)
+    const endpoint = await server.start()
+
+    const unauthorized = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+    })
+    expect(unauthorized.status).toBe(401)
+
+    const client = new Client({ name: 'debug-test', version: '1.0.0' })
+    const transport = new StreamableHTTPClientTransport(endpoint, {
+      requestInit: { headers: { Authorization: `Bearer ${server.authorizationToken}` } },
+    })
+    await client.connect(transport as unknown as Transport)
+
+    const catalog = await client.listTools()
+    expect(catalog.tools.map(tool => tool.name)).toEqual([
+      'debug_start',
+      'debug_breakpoint',
+      'debug_control',
+      'debug_context',
+    ])
+    const call = await client.callTool({ name: 'debug_context', arguments: {} })
+    const content = call.content[0]
+    expect(content?.type).toBe('text')
+    if (content?.type !== 'text') throw new Error('Expected a text tool result.')
+    expect(JSON.parse(content.text)).toMatchObject({ session: { sessionId: 'session-1', phase: 'stopped' } })
+    expect(tools.context).toHaveBeenCalledOnce()
+
+    await client.close()
+  })
+})

--- a/tests/debug-runtime-contribution.spec.ts
+++ b/tests/debug-runtime-contribution.spec.ts
@@ -3,6 +3,9 @@ import { supportsDebugRuntime } from '../src/debug-runtime-patch.ts'
 
 describe('debug runtime compatibility', () => {
   it('accepts rc.8, stable releases, and unknown custom executables', () => {
+    expect(supportsDebugRuntime('0.0.0')).toBe(false)
+    expect(supportsDebugRuntime('0.0.1')).toBe(false)
+    expect(supportsDebugRuntime('0.0.99-rc.99')).toBe(false)
     expect(supportsDebugRuntime('0.1.0-rc.7')).toBe(false)
     expect(supportsDebugRuntime('dsh 0.1.0-rc.8')).toBe(true)
     expect(supportsDebugRuntime('0.1.0')).toBe(true)

--- a/tests/debug-runtime-contribution.spec.ts
+++ b/tests/debug-runtime-contribution.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { supportsDebugRuntime } from '../src/debug-runtime-patch.ts'
+
+describe('debug runtime compatibility', () => {
+  it('accepts rc.8, stable releases, and unknown custom executables', () => {
+    expect(supportsDebugRuntime('0.1.0-rc.7')).toBe(false)
+    expect(supportsDebugRuntime('dsh 0.1.0-rc.8')).toBe(true)
+    expect(supportsDebugRuntime('0.1.0')).toBe(true)
+    expect(supportsDebugRuntime('0.1.1-rc.1')).toBe(true)
+    expect(supportsDebugRuntime('1.0.0')).toBe(true)
+    expect(supportsDebugRuntime(undefined)).toBe(true)
+    expect(supportsDebugRuntime('custom build')).toBe(true)
+  })
+})

--- a/tests/debug-runtime-patch.spec.ts
+++ b/tests/debug-runtime-patch.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { debugRuntimePatch, injectDebugRuntimePatch } from '../src/debug-runtime-patch.ts'
+
+describe('debug runtime patch', () => {
+  it('places launcher patches before Web application arguments', () => {
+    expect(injectDebugRuntimePatch(
+      ['web', '--host', '127.0.0.1', '--port', '0', '--no-open'],
+      '/tmp/debug.yml',
+    )).toEqual([
+      'web', '--patch', '/tmp/debug.yml', '--host', '127.0.0.1', '--port', '0', '--no-open',
+    ])
+    expect(injectDebugRuntimePatch(
+      ['--profile', 'web', '--host', '127.0.0.1'],
+      '/tmp/debug.yml',
+    )).toEqual([
+      '--profile', 'web', '--patch', '/tmp/debug.yml', '--host', '127.0.0.1',
+    ])
+  })
+
+  it('does not duplicate the same patch and rejects non-Web profiles', () => {
+    const args = ['web', '--patch', '/tmp/debug.yml', '--port', '0']
+    expect(injectDebugRuntimePatch(args, '/tmp/debug.yml')).toEqual(args)
+    expect(() => injectDebugRuntimePatch(['--profile', 'headless'], '/tmp/debug.yml'))
+      .toThrow('requires the DSH Web profile')
+  })
+
+  it('creates a token-free MCP overlay for the loopback endpoint', () => {
+    const patch = debugRuntimePatch(new URL('http://127.0.0.1:43127/mcp'))
+    expect(patch).toContain("name: '@deepseek-ai/dsh-mcp-client'")
+    expect(patch).toContain('url: http://127.0.0.1:43127/mcp')
+    expect(patch).toContain('process.env.DSH_VSCODE_DEBUG_TOKEN')
+    expect(patch).not.toContain('Bearer actual-token')
+    expect(() => debugRuntimePatch(new URL('http://localhost:43127/mcp'))).toThrow('IPv4 loopback')
+  })
+})

--- a/tests/debug-session-manager.spec.ts
+++ b/tests/debug-session-manager.spec.ts
@@ -64,4 +64,21 @@ describe('debug session ownership', () => {
     expect(owned.size).toBe(0)
     manager.dispose()
   })
+
+  it('returns a completed snapshot when a short launch terminates before start resolves', () => {
+    const manager = new DebugSessionManager()
+    const completed = session('short-task')
+    const owned = (manager as unknown as { owned: Map<string, unknown> }).owned
+    owned.set('short-task', {
+      session: completed,
+      workspace: 'file:///workspace/one',
+      state: { ...initialDebugSessionState(), phase: 'terminated' },
+    })
+
+    expect(manager.completeLaunch(true)).toMatchObject({
+      sessionId: 'short-task',
+      phase: 'terminated',
+    })
+    manager.dispose()
+  })
 })

--- a/tests/debug-session-manager.spec.ts
+++ b/tests/debug-session-manager.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const vscodeMock = vi.hoisted(() => ({
+  stopDebugging: vi.fn(async () => {}),
+}))
+
+vi.mock('vscode', () => ({
+  EventEmitter: class {
+    readonly event = vi.fn(() => ({ dispose: vi.fn() }))
+    fire(): void {}
+    dispose(): void {}
+  },
+  debug: {
+    activeDebugSession: undefined,
+    registerDebugAdapterTrackerFactory: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidStartDebugSession: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidTerminateDebugSession: vi.fn(() => ({ dispose: vi.fn() })),
+    stopDebugging: vscodeMock.stopDebugging,
+  },
+}))
+
+import { DebugSessionManager } from '../src/debug-session-manager.ts'
+import { initialDebugSessionState } from '../src/debug-state.ts'
+
+function folder(fsPath: string): never {
+  return { uri: { fsPath, toString: () => `file://${fsPath}` } } as never
+}
+
+function session(id: string, parentSession?: unknown): never {
+  return { id, name: id, type: 'node', parentSession } as never
+}
+
+describe('debug session ownership', () => {
+  it('stops root sessions and detaches their children when a workspace bridge is disposed', async () => {
+    const manager = new DebugSessionManager()
+    const root = session('root')
+    const child = session('child', root)
+    const other = session('other')
+    const owned = (manager as unknown as { owned: Map<string, unknown> }).owned
+    owned.set('root', { session: root, workspace: 'file:///workspace/one', state: { ...initialDebugSessionState(), phase: 'running' } })
+    owned.set('child', { session: child, workspace: 'file:///workspace/one', state: { ...initialDebugSessionState(), phase: 'stopped' } })
+    owned.set('other', { session: other, workspace: 'file:///workspace/two', state: { ...initialDebugSessionState(), phase: 'running' } })
+
+    await manager.stopOwnedSessions(folder('/workspace/one'))
+
+    expect(vscodeMock.stopDebugging).toHaveBeenCalledTimes(1)
+    expect(vscodeMock.stopDebugging).toHaveBeenCalledWith(root)
+    expect([...owned.keys()]).toEqual(['other'])
+    manager.dispose()
+  })
+
+  it('stops a live child whose parent already terminated', async () => {
+    vscodeMock.stopDebugging.mockClear()
+    const manager = new DebugSessionManager()
+    const root = session('terminated-root')
+    const child = session('live-child', root)
+    const owned = (manager as unknown as { owned: Map<string, unknown> }).owned
+    owned.set('terminated-root', { session: root, workspace: 'file:///workspace/one', state: { ...initialDebugSessionState(), phase: 'terminated' } })
+    owned.set('live-child', { session: child, workspace: 'file:///workspace/one', state: { ...initialDebugSessionState(), phase: 'running' } })
+
+    await manager.stopOwnedSessions(folder('/workspace/one'))
+
+    expect(vscodeMock.stopDebugging).toHaveBeenCalledWith(child)
+    expect(owned.size).toBe(0)
+    manager.dispose()
+  })
+})

--- a/tests/debug-state.spec.ts
+++ b/tests/debug-state.spec.ts
@@ -51,17 +51,51 @@ describe('debug session state', () => {
 
     expect(oneContinued.phase).toBe('stopped')
     expect(oneContinued.threads).toEqual({ 1: 'running', 2: 'stopped' })
+    expect(oneContinued.currentThreadId).toBe(2)
   })
 
-  it('marks execution controls running even when an adapter omits continued events', () => {
+  it('marks execution controls running after a successful response even when an adapter omits continued events', () => {
     const stopped = reduceDebugAdapterMessage(initialDebugSessionState(), {
       type: 'event', event: 'stopped', body: { reason: 'breakpoint', threadId: 4 },
     })
     const requested = reduceDebugAdapterMessage(stopped, {
       type: 'request', command: 'next', arguments: { threadId: 4 },
     })
+    expect(requested).toBe(stopped)
+    const accepted = reduceDebugAdapterMessage(requested, {
+      type: 'response', command: 'next', request_seq: 12, success: true,
+    })
 
-    expect(requested).toEqual({ phase: 'running', stopEpoch: 1, threads: { 4: 'running' } })
+    expect(accepted).toEqual({ phase: 'running', stopEpoch: 1, threads: { 4: 'running' } })
+  })
+
+  it('keeps stopped state when an execution request fails', () => {
+    const stopped = reduceDebugAdapterMessage(initialDebugSessionState(), {
+      type: 'event', event: 'stopped', body: { reason: 'breakpoint', threadId: 4 },
+    })
+    const failed = reduceDebugAdapterMessage(stopped, {
+      type: 'response', command: 'next', request_seq: 12, success: false,
+    })
+
+    expect(failed).toBe(stopped)
+  })
+
+  it('treats an omitted allThreadsContinued flag as thread-local', () => {
+    const first = reduceDebugAdapterMessage(initialDebugSessionState(), {
+      type: 'event', event: 'stopped', body: { reason: 'pause', threadId: 1 },
+    })
+    const second = reduceDebugAdapterMessage(first, {
+      type: 'event', event: 'stopped', body: { reason: 'pause', threadId: 2 },
+    })
+    const continued = reduceDebugAdapterMessage(second, {
+      type: 'event', event: 'continued', body: { threadId: 2 },
+    })
+
+    expect(continued).toMatchObject({
+      phase: 'stopped',
+      currentThreadId: 1,
+      threads: { 1: 'stopped', 2: 'running' },
+    })
   })
 
   it('treats exited and terminated as terminal states', () => {

--- a/tests/debug-state.spec.ts
+++ b/tests/debug-state.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { initialDebugSessionState, reduceDebugAdapterMessage } from '../src/debug-state.ts'
+
+describe('debug session state', () => {
+  it('tracks a normal stop, continue, and second stop without reusing the epoch', () => {
+    const initial = initialDebugSessionState()
+    const stopped = reduceDebugAdapterMessage(initial, {
+      type: 'event',
+      event: 'stopped',
+      body: { reason: 'breakpoint', threadId: 7, allThreadsStopped: true },
+    })
+    expect(stopped).toMatchObject({
+      phase: 'stopped',
+      stopEpoch: 1,
+      currentThreadId: 7,
+      stopReason: 'breakpoint',
+      threads: { 7: 'stopped' },
+    })
+
+    const running = reduceDebugAdapterMessage(stopped, {
+      type: 'event',
+      event: 'continued',
+      body: { threadId: 7, allThreadsContinued: true },
+    })
+    expect(running).toEqual({ phase: 'running', stopEpoch: 1, threads: { 7: 'running' } })
+
+    const stepped = reduceDebugAdapterMessage(running, {
+      type: 'event',
+      event: 'stopped',
+      body: { reason: 'step', threadId: 7 },
+    })
+    expect(stepped).toMatchObject({ phase: 'stopped', stopEpoch: 2, stopReason: 'step' })
+  })
+
+  it('keeps a session stopped while another thread continues', () => {
+    const oneStopped = reduceDebugAdapterMessage(initialDebugSessionState(), {
+      type: 'event',
+      event: 'stopped',
+      body: { reason: 'pause', threadId: 1 },
+    })
+    const twoStopped = reduceDebugAdapterMessage(oneStopped, {
+      type: 'event',
+      event: 'stopped',
+      body: { reason: 'pause', threadId: 2 },
+    })
+    const oneContinued = reduceDebugAdapterMessage(twoStopped, {
+      type: 'event',
+      event: 'continued',
+      body: { threadId: 1, allThreadsContinued: false },
+    })
+
+    expect(oneContinued.phase).toBe('stopped')
+    expect(oneContinued.threads).toEqual({ 1: 'running', 2: 'stopped' })
+  })
+
+  it('marks execution controls running even when an adapter omits continued events', () => {
+    const stopped = reduceDebugAdapterMessage(initialDebugSessionState(), {
+      type: 'event', event: 'stopped', body: { reason: 'breakpoint', threadId: 4 },
+    })
+    const requested = reduceDebugAdapterMessage(stopped, {
+      type: 'request', command: 'next', arguments: { threadId: 4 },
+    })
+
+    expect(requested).toEqual({ phase: 'running', stopEpoch: 1, threads: { 4: 'running' } })
+  })
+
+  it('treats exited and terminated as terminal states', () => {
+    const running = reduceDebugAdapterMessage(initialDebugSessionState(), { type: 'event', event: 'process' })
+    expect(reduceDebugAdapterMessage(running, { type: 'event', event: 'exited' }))
+      .toEqual({ phase: 'terminated', stopEpoch: 0, threads: {} })
+  })
+})

--- a/tests/debug-values.spec.ts
+++ b/tests/debug-values.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { compactDebugText, debugVariableValue, launchConfigurationNames } from '../src/debug-values.ts'
+
+describe('debug tool values', () => {
+  it('selects only named static launch and attach configurations', () => {
+    expect(launchConfigurationNames([
+      { name: 'Launch app', type: 'node', request: 'launch' },
+      { name: 'Attach app', type: 'node', request: 'attach' },
+      { name: 'Launch app', type: 'python', request: 'launch' },
+      { name: '', type: 'node', request: 'launch' },
+      { name: 'Compound-like', configurations: ['Launch app'] },
+    ])).toEqual(['Launch app', 'Attach app'])
+  })
+
+  it('redacts sensitive values by variable name', () => {
+    expect(debugVariableValue('api_key', 'sk-secret', 'string', 0)).toEqual({
+      name: 'api_key',
+      value: '<redacted>',
+      type: 'string',
+      expandable: false,
+    })
+    expect(debugVariableValue('userPassword', 'hidden', undefined, 0).value).toBe('<redacted>')
+    expect(debugVariableValue('session_token', 'secret', undefined, 3).expandable).toBe(true)
+  })
+
+  it('keeps debugger output single-line and bounded', () => {
+    expect(compactDebugText('one\n\ttwo', 20)).toBe('one two')
+    expect(compactDebugText('1234567890', 6)).toBe('12345…')
+  })
+})

--- a/tests/debug-values.spec.ts
+++ b/tests/debug-values.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { compactDebugText, debugVariableValue, launchConfigurationNames } from '../src/debug-values.ts'
+import { compactDebugText, debugVariableValue, isRuntimeInternalSource, launchConfigurationNames } from '../src/debug-values.ts'
 
 describe('debug tool values', () => {
   it('selects only named static launch and attach configurations', () => {
@@ -26,5 +26,11 @@ describe('debug tool values', () => {
   it('keeps debugger output single-line and bounded', () => {
     expect(compactDebugText('one\n\ttwo', 20)).toBe('one two')
     expect(compactDebugText('1234567890', 6)).toBe('12345…')
+  })
+
+  it('recognizes Node runtime frames that should stay out of agent context', () => {
+    expect(isRuntimeInternalSource('<node_internals>/internal/modules/cjs/loader')).toBe(true)
+    expect(isRuntimeInternalSource('node:internal/modules/run_main')).toBe(true)
+    expect(isRuntimeInternalSource('/workspace/src/index.js')).toBe(false)
   })
 })

--- a/tests/debug-workspace.spec.ts
+++ b/tests/debug-workspace.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { debugWorkspaceForPath } from '../src/debug-workspace.ts'
+
+function folder(name: string, fsPath: string): never {
+  return { name, uri: { fsPath } } as never
+}
+
+describe('debug workspace selection', () => {
+  it('binds tools to the workspace selected for the runtime launch', () => {
+    const frontend = folder('frontend', '/workspace/frontend')
+    const backend = folder('backend', '/workspace/backend')
+
+    expect(debugWorkspaceForPath([frontend, backend], '/workspace/backend')).toBe(backend)
+    expect(debugWorkspaceForPath([frontend, backend], '/workspace/missing')).toBeUndefined()
+  })
+})

--- a/tests/runtime-cleanup.spec.ts
+++ b/tests/runtime-cleanup.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('vscode', () => ({
+  EventEmitter: class {
+    readonly event = vi.fn()
+    fire(): void {}
+    dispose(): void {}
+  },
+}))
+
+import { DshRuntime } from '../src/runtime.ts'
+import type { RuntimeLaunchPreparation } from '../src/runtime-launch.ts'
+
+interface RuntimeCleanupAccess {
+  launchPreparation: RuntimeLaunchPreparation | undefined
+  releaseLaunchPreparation(): Promise<void>
+}
+
+describe('runtime launch cleanup', () => {
+  it('shares an in-flight asynchronous cleanup with every waiter', async () => {
+    let finishDisposal: (() => void) | undefined
+    const dispose = vi.fn(() => new Promise<void>(resolve => { finishDisposal = resolve }))
+    const runtime = new DshRuntime({} as never, { appendLine: vi.fn() } as never)
+    const cleanup = runtime as unknown as RuntimeCleanupAccess
+    cleanup.launchPreparation = { transformArguments: args => [...args], dispose }
+
+    const fromExitHandler = cleanup.releaseLaunchPreparation()
+    const fromStop = cleanup.releaseLaunchPreparation()
+    let stopFinished = false
+    void fromStop.then(() => { stopFinished = true })
+    await Promise.resolve()
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(stopFinished).toBe(false)
+
+    finishDisposal?.()
+    await Promise.all([fromExitHandler, fromStop])
+    expect(stopFinished).toBe(true)
+
+    await cleanup.releaseLaunchPreparation()
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/runtime-launch.spec.ts
+++ b/tests/runtime-launch.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyRuntimeLaunchPreparation,
+  type RuntimeLaunchPreparation,
+} from '../src/runtime-launch.ts'
+
+describe('managed runtime launch contributions', () => {
+  it('preserves the configured arguments when no contribution is active', () => {
+    const args = ['web', '--host', '127.0.0.1', '--port', '0']
+
+    expect(applyRuntimeLaunchPreparation(args, '0.1.0-rc.8', undefined)).toEqual(args)
+  })
+
+  it('lets a contribution transform versioned arguments without mutating them', () => {
+    const args = ['web', '--host', '127.0.0.1', '--port', '0', '--no-open']
+    const transformArguments = vi.fn((current: readonly string[], version: string | undefined) => [
+      current[0] ?? 'web',
+      '--patch',
+      `/tmp/debug-${version ?? 'unknown'}.yml`,
+      ...current.slice(1),
+    ])
+    const preparation: RuntimeLaunchPreparation = { transformArguments }
+
+    expect(applyRuntimeLaunchPreparation(args, '0.1.0-rc.8', preparation)).toEqual([
+      'web',
+      '--patch',
+      '/tmp/debug-0.1.0-rc.8.yml',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      '0',
+      '--no-open',
+    ])
+    expect(args).toEqual(['web', '--host', '127.0.0.1', '--port', '0', '--no-open'])
+    expect(transformArguments).toHaveBeenCalledWith(args, '0.1.0-rc.8')
+  })
+})

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -25,4 +25,17 @@ describe('chat webview', () => {
     expect(script).toContain("pendingMessageAppends.set(append.id")
     expect(script).toContain("target.textContent += continuation.textContent")
   })
+
+  it('detaches tail following before loading earlier history', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const script = /<script nonce="[^"]+">([\s\S]*?)<\/script>/.exec(chatHtml(webview, mark))?.[1] ?? ''
+    const historyClick = script.indexOf("button.addEventListener('click'")
+    const detachTail = script.indexOf('detachConversationTail();', historyClick)
+    const requestHistory = script.indexOf("vscode.postMessage({ type: 'load-history' })", historyClick)
+
+    expect(historyClick).toBeGreaterThanOrEqual(0)
+    expect(detachTail).toBeGreaterThan(historyClick)
+    expect(detachTail).toBeLessThan(requestHistory)
+  })
 })

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -38,4 +38,14 @@ describe('chat webview', () => {
     expect(detachTail).toBeGreaterThan(historyClick)
     expect(detachTail).toBeLessThan(requestHistory)
   })
+
+  it('updates tail following from every scroll source', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const script = /<script nonce="[^"]+">([\s\S]*?)<\/script>/.exec(chatHtml(webview, mark))?.[1] ?? ''
+
+    expect(script).toContain("elements.scroll.addEventListener('scroll', synchronizeConversationTail")
+    expect(script).toContain('if (conversationNearBottom()) followConversationTail = true;')
+    expect(script).not.toContain("elements.scroll.addEventListener('wheel'")
+  })
 })

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -21,6 +21,7 @@ describe('chat webview', () => {
     expect(script).toContain('controller.append(event.data.page.message')
     expect(script).not.toContain('renderedMessages.delete(event.data.messageId)')
     expect(script).not.toContain('value.startsWith(stream.text)')
+    expect(script).not.toContain('rendered.node.replaceWith')
     expect(script).toContain("pendingMessageAppends.set(append.id")
     expect(script).toContain("target.textContent += continuation.textContent")
   })


### PR DESCRIPTION
## Summary

Bring the native VS Code debugger into DSH so the agent can start, inspect, step through, fix, and verify code without requiring manual @ mentions.

This first commit adds the managed-runtime launch contribution layer needed to inject the protected debug bridge without changing existing runtime behavior.

## Planned scope

- Workspace-scoped opt-in and authorization
- Debug session and per-thread state tracking
- Breakpoints, stack frames, scopes, and variables
- Continue, pause, step, restart, and stop controls
- Authenticated loopback MCP bridge through the official DSH MCP client
- Native debug tool presentation in the sidebar

## Safety boundaries

- Only existing workspace launch configurations
- Agent-owned debug sessions by default
- Dirty-buffer protection before launch or restart
- No evaluate, variable mutation, or arbitrary DAP requests
- Bounded and redacted variable output

## Verification

- npm run check