### PR TITLE
fix: improve Windows compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,11 @@ concurrency:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/src/diff-review.ts
+++ b/src/diff-review.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'node:crypto'
 import * as vscode from 'vscode'
 import type { DshEvent } from './conversation.js'
 import type { HistoryEntry } from './dsh-client.js'
+import { comparableFilePath } from './file-path.js'
 
 export interface ChangedFileItem {
   path: string
@@ -433,7 +434,11 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
   }
 
   private validateCurrentFile(review: ReviewFile, expected: string | null): void {
-    const dirty = vscode.workspace.textDocuments.some(document => document.isDirty && path.resolve(document.uri.fsPath) === review.absolutePath)
+    const reviewPath = comparableFilePath(review.absolutePath)
+    const dirty = vscode.workspace.textDocuments.some(document =>
+      document.isDirty
+      && comparableFilePath(path.resolve(document.uri.fsPath)) === reviewPath,
+    )
     if (dirty) throw new Error(`Cannot revert ${review.displayPath}: it has unsaved VS Code changes.`)
     const current = readImage(review.absolutePath)
     if (current === undefined) throw new Error(`Cannot safely read ${review.displayPath} before reverting.`)

--- a/src/diff-review.ts
+++ b/src/diff-review.ts
@@ -125,9 +125,10 @@ function groupedDiffs(cwd: string, diffs: readonly FileDiff[], turn: number): Ma
   for (const diff of diffs) {
     const absolutePath = projectPath(cwd, diff.path)
     if (absolutePath === undefined) continue
-    const existing = grouped.get(absolutePath)
+    const key = comparableFilePath(absolutePath)
+    const existing = grouped.get(key)
     if (existing === undefined) {
-      grouped.set(absolutePath, {
+      grouped.set(key, {
         absolutePath,
         displayPath: path.relative(cwd, absolutePath) || path.basename(absolutePath),
         diffs: [diff],
@@ -229,12 +230,14 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
     if (failedResult(event)) return false
 
     const results = groupedDiffs(cwd, diffsOf(view, 'result'), turn)
-    const absolutePaths = new Set([...(pending?.keys() ?? []), ...results.keys()])
+    const fileKeys = new Set([...(pending?.keys() ?? []), ...results.keys()])
     let updated = false
-    for (const absolutePath of absolutePaths) {
-      const callFile = pending?.get(absolutePath)
-      const resultFile = results.get(absolutePath)
-      const displayPath = resultFile?.displayPath ?? callFile?.displayPath ?? path.relative(cwd, absolutePath)
+    for (const fileKey of fileKeys) {
+      const callFile = pending?.get(fileKey)
+      const resultFile = results.get(fileKey)
+      const absolutePath = callFile?.absolutePath ?? resultFile?.absolutePath
+      if (absolutePath === undefined) continue
+      const displayPath = callFile?.displayPath ?? resultFile?.displayPath ?? path.relative(cwd, absolutePath)
       const fileTurn = resultFile?.turn ?? callFile?.turn ?? turn
       const diffs = resultFile?.diffs ?? callFile?.diffs ?? []
       const after = replay ? undefined : readImage(absolutePath)
@@ -329,8 +332,9 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
     if (reviews.length === 0) throw new Error('No completed DeepSeek changes are available to revert.')
     const byFile = new Map<string, ReviewFile[]>()
     for (const review of reviews) {
-      const existing = byFile.get(review.absolutePath)
-      if (existing === undefined) byFile.set(review.absolutePath, [review])
+      const key = comparableFilePath(review.absolutePath)
+      const existing = byFile.get(key)
+      if (existing === undefined) byFile.set(key, [review])
       else existing.push(review)
     }
     const validated = [...byFile.values()].map(series => this.validateRevertSeries(series))
@@ -351,8 +355,9 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
     if (turns === undefined) this.reviews.set(sessionId, turns = new Map())
     let files = turns.get(incoming.turn)
     if (files === undefined) turns.set(incoming.turn, files = new Map())
-    const existing = files.get(incoming.absolutePath)
-    if (existing === undefined) files.set(incoming.absolutePath, incoming)
+    const key = comparableFilePath(incoming.absolutePath)
+    const existing = files.get(key)
+    if (existing === undefined) files.set(key, incoming)
     else existing.snapshots.push(...incoming.snapshots)
   }
 
@@ -374,11 +379,12 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
   private findReview(sessionId: string, cwd: string, value: string, turn?: number): ReviewFile | undefined {
     const absolutePath = projectPath(cwd, value)
     if (absolutePath === undefined) return undefined
+    const key = comparableFilePath(absolutePath)
     const turns = this.reviews.get(sessionId)
-    if (turn !== undefined) return turns?.get(turn)?.get(absolutePath)
+    if (turn !== undefined) return turns?.get(turn)?.get(key)
     return [...(turns?.entries() ?? [])]
       .sort(([left], [right]) => right - left)
-      .map(([, files]) => files.get(absolutePath))
+      .map(([, files]) => files.get(key))
       .find((review): review is ReviewFile => review !== undefined)
   }
 
@@ -387,7 +393,7 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
   }
 
   private reviewKey(review: ReviewFile): string {
-    return `${String(review.turn)}:${review.absolutePath}`
+    return `${String(review.turn)}:${comparableFilePath(review.absolutePath)}`
   }
 
   private markDismissed(sessionId: string, review: ReviewFile): void {
@@ -400,7 +406,7 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
     this.markDismissed(sessionId, review)
     const turns = this.reviews.get(sessionId)
     const files = turns?.get(review.turn)
-    files?.delete(review.absolutePath)
+    files?.delete(comparableFilePath(review.absolutePath))
     if (files?.size === 0) turns?.delete(review.turn)
     if (turns?.size === 0) this.reviews.delete(sessionId)
   }

--- a/src/diff-review.ts
+++ b/src/diff-review.ts
@@ -229,11 +229,16 @@ export class DiffReviewManager implements vscode.TextDocumentContentProvider, vs
     this.pending.delete(key)
     if (failedResult(event)) return false
 
+    // A newly created file may not have had a realpath during tool/call. Resolve
+    // pending entries again now that tool/result has made the path observable.
+    const currentPending = pending === undefined
+      ? undefined
+      : new Map([...pending.values()].map(file => [comparableFilePath(file.absolutePath), file]))
     const results = groupedDiffs(cwd, diffsOf(view, 'result'), turn)
-    const fileKeys = new Set([...(pending?.keys() ?? []), ...results.keys()])
+    const fileKeys = new Set([...(currentPending?.keys() ?? []), ...results.keys()])
     let updated = false
     for (const fileKey of fileKeys) {
-      const callFile = pending?.get(fileKey)
+      const callFile = currentPending?.get(fileKey)
       const resultFile = results.get(fileKey)
       const absolutePath = callFile?.absolutePath ?? resultFile?.absolutePath
       if (absolutePath === undefined) continue

--- a/src/dirty-file-guard.ts
+++ b/src/dirty-file-guard.ts
@@ -1,19 +1,14 @@
-import * as path from 'node:path'
 import * as vscode from 'vscode'
+import { comparableFilePath } from './file-path.js'
 import { absoluteToolPaths } from './tool-write-guard.js'
-
-function comparable(filePath: string): string {
-  const normalized = path.normalize(filePath)
-  return process.platform === 'darwin' || process.platform === 'win32' ? normalized.toLowerCase() : normalized
-}
 
 export class DirtyFileGuard {
   conflicts(cwd: string, toolPaths: readonly string[]): vscode.TextDocument[] {
-    const targets = new Set(absoluteToolPaths(cwd, toolPaths).map(comparable))
+    const targets = new Set(absoluteToolPaths(cwd, toolPaths).map(filePath => comparableFilePath(filePath)))
     return vscode.workspace.textDocuments.filter(document =>
       document.isDirty
       && document.uri.scheme === 'file'
-      && targets.has(comparable(document.uri.fsPath)),
+      && targets.has(comparableFilePath(document.uri.fsPath)),
     )
   }
 }

--- a/src/file-path.ts
+++ b/src/file-path.ts
@@ -1,0 +1,7 @@
+import * as path from 'node:path'
+
+/** Normalize filesystem paths using the host filesystem's case semantics. */
+export function comparableFilePath(filePath: string, platform: NodeJS.Platform = process.platform): string {
+  const normalized = path.normalize(filePath)
+  return platform === 'darwin' || platform === 'win32' ? normalized.toLowerCase() : normalized
+}

--- a/src/file-path.ts
+++ b/src/file-path.ts
@@ -1,7 +1,14 @@
+import * as fs from 'node:fs'
 import * as path from 'node:path'
 
-/** Normalize filesystem paths using the host filesystem's case semantics. */
-export function comparableFilePath(filePath: string, platform: NodeJS.Platform = process.platform): string {
+/** Resolve an existing path to its filesystem identity without guessing case semantics. */
+export function comparableFilePath(filePath: string): string {
   const normalized = path.normalize(filePath)
-  return platform === 'darwin' || platform === 'win32' ? normalized.toLowerCase() : normalized
+  try {
+    return path.normalize(fs.realpathSync.native(normalized))
+  } catch {
+    // Missing paths have no filesystem identity yet. Preserve their spelling so
+    // case-sensitive volumes never merge two distinct future files.
+    return normalized
+  }
 }

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -66,7 +66,7 @@ function comSpec(env: Readonly<Record<string, string | undefined>>): string {
   return environmentValue(env, 'ComSpec') || 'cmd.exe'
 }
 
-const WINDOWS_CMD_META = /([()\][%!^"`<>&|;, *?])/g
+const WINDOWS_CMD_META = /([()\][%!^"`<>&|;, *?\t])/g
 
 function safeWindowsShellValue(value: string): string {
   if (/[\0\r\n]/.test(value)) {

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
+import { dirname, extname, isAbsolute, join, relative, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 
 export interface LaunchCommand {
@@ -8,6 +8,7 @@ export interface LaunchCommand {
   args: string[]
   sourceCheckout: boolean
   env?: Readonly<Record<string, string>>
+  windowsVerbatimArguments?: boolean
 }
 
 interface LaunchHost {
@@ -33,6 +34,24 @@ function windowsPathDirectories(env: Readonly<Record<string, string | undefined>
     .filter(value => value !== '')
 }
 
+function environmentValue(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string | undefined {
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toLowerCase() === name.toLowerCase()) return value
+  }
+  return undefined
+}
+
+function windowsPathExtensions(env: Readonly<Record<string, string | undefined>>): string[] {
+  const configured = environmentValue(env, 'PATHEXT')
+    ?.split(';')
+    .map(value => value.trim())
+    .filter(value => value !== '')
+  return configured !== undefined && configured.length > 0 ? configured : ['.COM', '.EXE', '.BAT', '.CMD']
+}
+
 function executableBasename(executable: string): string {
   return executable.split(/[\\/]/).at(-1) ?? executable
 }
@@ -44,33 +63,96 @@ function isWindowsShellScript(executable: string): boolean {
 }
 
 function comSpec(env: Readonly<Record<string, string | undefined>>): string {
-  for (const [key, value] of Object.entries(env)) {
-    if (key.toLowerCase() === 'comspec' && value !== undefined && value !== '') return value
+  return environmentValue(env, 'ComSpec') || 'cmd.exe'
+}
+
+const WINDOWS_CMD_META = /([()\][%!^"`<>&|;, *?])/g
+
+function safeWindowsShellValue(value: string): string {
+  if (/[\0\r\n]/.test(value)) {
+    throw new Error('Windows shell commands and arguments cannot contain NUL or newline characters.')
   }
-  return 'cmd.exe'
+  return value
+}
+
+function escapeWindowsShellCommand(value: string): string {
+  return safeWindowsShellValue(value).replace(WINDOWS_CMD_META, '^$1')
+}
+
+function escapeWindowsShellArgument(value: string, doubleEscapeMeta: boolean): string {
+  let escaped = safeWindowsShellValue(value)
+  // Match CommandLineToArgvW quoting before cmd.exe consumes its own syntax.
+  escaped = escaped.replace(/(?=(\\+?)?)\1"/g, '$1$1\\"')
+  escaped = escaped.replace(/(?=(\\+?)?)\1$/g, '$1$1')
+  escaped = `"${escaped}"`.replace(WINDOWS_CMD_META, '^$1')
+  return doubleEscapeMeta ? escaped.replace(WINDOWS_CMD_META, '^$1') : escaped
 }
 
 /**
- * Run a Windows .cmd/.bat shim through the command interpreter. cmd.exe /c
- * launches the shim without spawn's direct-.cmd EINVAL and without shell:true's
- * unescaped-argument hazard (DEP0190). Used as a last resort when the npm JS
- * entry cannot be resolved (e.g. pnpm/yarn/volta global install layouts).
+ * Run a Windows .cmd/.bat shim through cmd.exe with every token pre-escaped.
+ * windowsVerbatimArguments prevents Node from quoting the already encoded
+ * command a second time. Used only when a shell-free executable or npm JS
+ * entry cannot be resolved.
  */
 function windowsShellFallback(
   command: string,
   args: readonly string[],
   env: Readonly<Record<string, string | undefined>>,
 ): LaunchCommand {
+  const doubleEscapeMeta = /node_modules[\\/]\.bin[\\/][^\\/]+\.cmd$/i.test(command)
+  const shellCommand = [
+    escapeWindowsShellCommand(command),
+    ...args.map(value => escapeWindowsShellArgument(value, doubleEscapeMeta)),
+  ].join(' ')
   return {
     command: comSpec(env),
-    args: ['/c', command, ...args],
+    args: ['/d', '/s', '/c', `"${shellCommand}"`],
     sourceCheckout: false,
+    windowsVerbatimArguments: true,
   }
 }
 
 function explicitExecutablePath(executable: string, cwd: string): string {
   if (isAbsolute(executable)) return executable
   return resolve(cwd, ...executable.split(/[\\/]+/))
+}
+
+function existingWindowsFile(directory: string, fileName: string): string | undefined {
+  try {
+    const entry = readdirSync(directory).find(value => value.toLowerCase() === fileName.toLowerCase())
+    if (entry === undefined) return undefined
+    const candidate = join(directory, entry)
+    return statSync(candidate).isFile() ? candidate : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Resolve exactly the command Windows would pick from PATH and PATHEXT. */
+function resolveWindowsPathCommand(executable: string, host: LaunchHost): string | undefined {
+  const hasDirectory = /[\\/]/.test(executable)
+  const explicitPath = hasDirectory ? explicitExecutablePath(executable, host.cwd) : undefined
+  const searchDirectories = [
+    ...(environmentValue(host.env, 'NoDefaultCurrentDirectoryInExePath') === undefined ? [host.cwd] : []),
+    ...windowsPathDirectories(host.env),
+  ]
+  const directories = explicitPath === undefined
+    ? searchDirectories.filter((value, index, values) => (
+        values.findIndex(candidate => candidate.toLowerCase() === value.toLowerCase()) === index
+      ))
+    : [dirname(explicitPath)]
+  const name = executableBasename(explicitPath ?? executable)
+  const names = extname(name) === ''
+    ? windowsPathExtensions(host.env).map(extension => `${name}${extension.startsWith('.') ? extension : `.${extension}`}`)
+    : [name]
+
+  for (const directory of directories) {
+    for (const candidate of names) {
+      const match = existingWindowsFile(directory, candidate)
+      if (match !== undefined) return match
+    }
+  }
+  return undefined
 }
 
 function installedDshEntry(binDirectory: string): string | undefined {
@@ -127,25 +209,31 @@ function resolveWindowsDsh(
   const basename = executableBasename(executable).toLowerCase()
   if (executable !== '' && basename !== 'dsh' && basename !== 'dsh.cmd') return undefined
 
-  const explicitPath = executable !== '' && /[\\/]/.test(executable)
-    ? explicitExecutablePath(executable, host.cwd)
-    : undefined
-  const directories = explicitPath === undefined
-    ? windowsPathDirectories(host.env)
-    : [dirname(explicitPath)]
-  for (const directory of directories) {
-    if (!existsSync(join(directory, 'dsh.cmd'))) continue
-    const entry = installedDshEntry(directory)
-    if (entry === undefined) continue
-    const node = windowsNodeExecutable(directory, host.env)
-    if (node === undefined) continue
-    return {
-      command: node,
-      args: [entry, ...configuredArgs],
-      sourceCheckout: false,
+  const requested = executable === '' ? 'dsh' : executable
+  const match = resolveWindowsPathCommand(requested, host)
+  if (match !== undefined) {
+    if (!isWindowsShellScript(match)) {
+      return { command: match, args: [...configuredArgs], sourceCheckout: false }
     }
+    if (match.toLowerCase().endsWith('.cmd')) {
+      const directory = dirname(match)
+      const entry = installedDshEntry(directory)
+      const node = entry === undefined ? undefined : windowsNodeExecutable(directory, host.env)
+      if (entry !== undefined && node !== undefined) {
+        return {
+          command: node,
+          args: [entry, ...configuredArgs],
+          sourceCheckout: false,
+        }
+      }
+    }
+    return windowsShellFallback(match, configuredArgs, host.env)
   }
-  return undefined
+
+  const fallback = /[\\/]/.test(requested)
+    ? explicitExecutablePath(requested, host.cwd)
+    : requested
+  return windowsShellFallback(fallback, configuredArgs, host.env)
 }
 
 function supportsNoOpen(version: string): boolean {
@@ -229,16 +317,10 @@ export function resolveLaunch(
       const windowsLaunch = resolveWindowsDsh(configuredExecutable, configuredArgs, host)
       if (windowsLaunch !== undefined) return windowsLaunch
       if (isWindowsShellScript(configuredExecutable)) {
-        // Settings JSON favors forward slashes, which cmd.exe mis-parses in an
-        // unquoted command token. resolve() also pins relative paths to the
-        // extension cwd instead of whatever directory cmd starts in.
         const command = /[\\/]/.test(configuredExecutable)
           ? explicitExecutablePath(configuredExecutable, host.cwd)
           : configuredExecutable
         return windowsShellFallback(command, configuredArgs, host.env)
-      }
-      if (configuredExecutable.toLowerCase() === 'dsh') {
-        return windowsShellFallback('dsh', configuredArgs, host.env)
       }
     }
     return {
@@ -272,9 +354,6 @@ export function resolveLaunch(
   if (host.platform === 'win32') {
     const windowsLaunch = resolveWindowsDsh('', configuredArgs, host)
     if (windowsLaunch !== undefined) return windowsLaunch
-    // Extensionless so cmd.exe applies PATHEXT: finds npm/pnpm/yarn dsh.cmd
-    // and also volta/scoop dsh.exe shims, which have no .cmd sibling.
-    return windowsShellFallback('dsh', configuredArgs, host.env)
   }
 
   return {

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -62,6 +62,12 @@ function isWindowsShellScript(executable: string): boolean {
   return basename.endsWith('.cmd') || basename.endsWith('.bat')
 }
 
+/** CreateProcess can launch these formats without consulting cmd.exe. */
+function isWindowsNativeExecutable(executable: string): boolean {
+  const extension = extname(executableBasename(executable)).toLowerCase()
+  return extension === '.exe' || extension === '.com'
+}
+
 function comSpec(env: Readonly<Record<string, string | undefined>>): string {
   return environmentValue(env, 'ComSpec') || 'cmd.exe'
 }
@@ -212,7 +218,7 @@ function resolveWindowsDsh(
   const requested = executable === '' ? 'dsh' : executable
   const match = resolveWindowsPathCommand(requested, host)
   if (match !== undefined) {
-    if (!isWindowsShellScript(match)) {
+    if (isWindowsNativeExecutable(match)) {
       return { command: match, args: [...configuredArgs], sourceCheckout: false }
     }
     if (match.toLowerCase().endsWith('.cmd')) {

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -124,7 +124,8 @@ function resolveWindowsDsh(
   configuredArgs: readonly string[],
   host: LaunchHost,
 ): LaunchCommand | undefined {
-  if (executable !== '' && executableBasename(executable).toLowerCase() !== 'dsh.cmd') return undefined
+  const basename = executableBasename(executable).toLowerCase()
+  if (executable !== '' && basename !== 'dsh' && basename !== 'dsh.cmd') return undefined
 
   const explicitPath = executable !== '' && /[\\/]/.test(executable)
     ? explicitExecutablePath(executable, host.cwd)
@@ -235,6 +236,9 @@ export function resolveLaunch(
           ? explicitExecutablePath(configuredExecutable, host.cwd)
           : configuredExecutable
         return windowsShellFallback(command, configuredArgs, host.env)
+      }
+      if (configuredExecutable.toLowerCase() === 'dsh') {
+        return windowsShellFallback('dsh', configuredArgs, host.env)
       }
     }
     return {

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -536,6 +536,7 @@ export class DshPluginManager {
         env: { ...process.env, NO_COLOR: '1', ...launch.env },
         stdio: ['ignore', 'pipe', 'pipe'],
         windowsHide: true,
+        windowsVerbatimArguments: launch.windowsVerbatimArguments,
       })
       const append = (chunk: Buffer | string): void => {
         const text = String(chunk)

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import * as vscode from 'vscode'
 import { resolveLaunch } from './launch.js'
+import { terminateProcessTree } from './process-tree.js'
 import {
   COMMUNITY_REGISTRY_URL,
   parseCommunityRuntimePlugins,
@@ -545,7 +546,7 @@ export class DshPluginManager {
       child.stderr.on('data', append)
       const cancellation = token.onCancellationRequested(() => {
         cancelled = true
-        child.kill('SIGTERM')
+        terminateProcessTree(child)
       })
       child.once('error', (error) => {
         if (settled) return

--- a/src/plugin-manager.ts
+++ b/src/plugin-manager.ts
@@ -510,15 +510,17 @@ export class DshPluginManager {
   }
 
   private async runOfficialPluginCommand(args: readonly string[], title: string): Promise<void> {
-    const workspace = vscode.workspace.workspaceFolders?.[0]?.uri
+    const defaultWorkspace = vscode.workspace.workspaceFolders?.[0]?.uri
+    const cwd = this.controller.cwd || defaultWorkspace?.fsPath || process.cwd()
+    const workspace = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(cwd))?.uri ?? defaultWorkspace
     const config = vscode.workspace.getConfiguration('deepseekHarness', workspace)
     const executable = config.get<string>('executable', '')
     const launch = resolveLaunch(
       this.context.extensionUri.fsPath,
       executable,
       ['plugin', '--profile', 'web', ...args],
+      { cwd },
     )
-    const cwd = this.controller.cwd || workspace?.fsPath || process.cwd()
     const rendered = [launch.command, ...launch.args].map(part => JSON.stringify(part)).join(' ')
     this.output.appendLine(`[plugins] cwd: ${cwd}`)
     this.output.appendLine(`[plugins] launch: ${rendered}`)

--- a/src/process-tree.ts
+++ b/src/process-tree.ts
@@ -1,0 +1,48 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+
+type KillableProcess = Pick<ChildProcess, 'pid' | 'exitCode' | 'signalCode' | 'kill'>
+
+interface ProcessTreeHost {
+  platform: NodeJS.Platform
+  spawnProcess: typeof spawn
+}
+
+/**
+ * Stop a child and, on Windows, every descendant created by cmd.exe shims.
+ * Node's child.kill() only targets the wrapper process there, which can leave
+ * the actual DSH or package-manager process running in the background.
+ */
+export function terminateProcessTree(
+  child: KillableProcess,
+  signal: NodeJS.Signals = 'SIGTERM',
+  overrides: Partial<ProcessTreeHost> = {},
+): boolean {
+  if (child.exitCode !== null || child.signalCode !== null) return false
+
+  const platform = overrides.platform ?? process.platform
+  if (platform !== 'win32' || child.pid === undefined) return child.kill(signal)
+
+  const spawnProcess = overrides.spawnProcess ?? spawn
+  let fellBack = false
+  const fallback = (): void => {
+    if (fellBack || child.exitCode !== null || child.signalCode !== null) return
+    fellBack = true
+    child.kill('SIGKILL')
+  }
+
+  try {
+    const taskkill = spawnProcess(
+      'taskkill.exe',
+      ['/PID', String(child.pid), '/T', '/F'],
+      { stdio: 'ignore', windowsHide: true },
+    )
+    taskkill.once('error', fallback)
+    taskkill.once('close', code => {
+      if (code !== 0) fallback()
+    })
+    return true
+  } catch {
+    fallback()
+    return fellBack
+  }
+}

--- a/src/process-tree.ts
+++ b/src/process-tree.ts
@@ -1,10 +1,22 @@
 import { spawn, type ChildProcess } from 'node:child_process'
+import { win32 as windowsPath } from 'node:path'
 
 type KillableProcess = Pick<ChildProcess, 'pid' | 'exitCode' | 'signalCode' | 'kill'>
 
 interface ProcessTreeHost {
   platform: NodeJS.Platform
   spawnProcess: typeof spawn
+  env: Readonly<Record<string, string | undefined>>
+}
+
+function environmentValue(
+  env: Readonly<Record<string, string | undefined>>,
+  name: string,
+): string | undefined {
+  for (const [key, value] of Object.entries(env)) {
+    if (key.toLowerCase() === name.toLowerCase()) return value
+  }
+  return undefined
 }
 
 /**
@@ -23,6 +35,7 @@ export function terminateProcessTree(
   if (platform !== 'win32' || child.pid === undefined) return child.kill(signal)
 
   const spawnProcess = overrides.spawnProcess ?? spawn
+  const env = overrides.env ?? process.env
   let fellBack = false
   const fallback = (): void => {
     if (fellBack || child.exitCode !== null || child.signalCode !== null) return
@@ -30,9 +43,16 @@ export function terminateProcessTree(
     child.kill('SIGKILL')
   }
 
+  const systemRoot = environmentValue(env, 'SystemRoot') || environmentValue(env, 'windir')
+  if (systemRoot === undefined) {
+    fallback()
+    return fellBack
+  }
+  const taskkillExecutable = windowsPath.join(systemRoot, 'System32', 'taskkill.exe')
+
   try {
     const taskkill = spawnProcess(
-      'taskkill.exe',
+      taskkillExecutable,
       ['/PID', String(child.pid), '/T', '/F'],
       { stdio: 'ignore', windowsHide: true },
     )

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -57,6 +57,7 @@ function readDshVersion(launch: LaunchCommand, cwd: string): Promise<string | un
         env: { ...process.env, NO_COLOR: '1', ...launch.env },
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
+        windowsVerbatimArguments: launch.windowsVerbatimArguments,
       })
     } catch {
       finish()
@@ -208,6 +209,7 @@ export class DshRuntime implements vscode.Disposable {
         },
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,
+        windowsVerbatimArguments: launch.windowsVerbatimArguments,
       })
     } catch (error) {
       this.failStart(error instanceof Error ? error : new Error(String(error)), pending)

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -13,6 +13,7 @@ import {
   type RuntimeLaunchContributor,
   type RuntimeLaunchPreparation,
 } from './runtime-launch.js'
+import { terminateProcessTree } from './process-tree.js'
 
 export type RuntimeOwnership = 'external' | 'managed'
 
@@ -70,7 +71,7 @@ function readDshVersion(launch: LaunchCommand, cwd: string): Promise<string | un
     // version string cannot be truncated by a late stdout chunk.
     child.on('close', code => { finish(code === 0 ? output.trim() : undefined) })
     timer = setTimeout(() => {
-      child.kill()
+      terminateProcessTree(child)
       finish()
     }, 5_000)
   })
@@ -340,10 +341,10 @@ export class DshRuntime implements vscode.Disposable {
       }
       child.once('exit', finish)
       forceTimer = setTimeout(() => {
-        child.kill('SIGKILL')
+        terminateProcessTree(child, 'SIGKILL')
         finish()
       }, 4_000)
-      if (!child.kill('SIGTERM')) finish()
+      if (!terminateProcessTree(child)) finish()
     })
     await this.releaseLaunchPreparation()
     this.publish({ kind: 'stopped' })

--- a/tests/diff-review.spec.ts
+++ b/tests/diff-review.spec.ts
@@ -131,35 +131,74 @@ describe('DiffReviewManager', () => {
     expect(fs.readFileSync(filePath, 'utf8')).toBe('const value = 1\n')
   })
 
-  it.runIf(process.platform === 'win32' || process.platform === 'darwin')(
-    'treats differently cased diff paths as the same file',
-    () => {
-      const cwd = temporaryWorkspace()
-      const filePath = path.join(cwd, 'CaseFile.ts')
-      fs.writeFileSync(filePath, 'before\n')
-      const manager = new DiffReviewManager()
-      const callId = 'case-insensitive-path'
-      const call = event('tool/call', 1, { turn: 1, callId, name: 'edit' })
-      const result = event('tool/result', 2, {
-        turn: 1,
-        message: { source: { kind: 'tool', callId }, content: [] },
-      })
-      const view = (forValue: 'call' | 'result', fileName: string) => ({
-        for: forValue,
-        view: { card: 'diff', diffs: [{ path: fileName, oldText: 'before', newText: 'after' }] },
-      })
+  it('treats differently cased aliases as the same file on a case-insensitive filesystem', () => {
+    const cwd = temporaryWorkspace()
+    const filePath = path.join(cwd, 'CaseFile.ts')
+    fs.writeFileSync(filePath, 'before\n')
+    if (!fs.existsSync(path.join(cwd, 'casefile.ts'))) return
+    const manager = new DiffReviewManager()
+    const callId = 'case-insensitive-path'
+    const call = event('tool/call', 1, { turn: 1, callId, name: 'edit' })
+    const result = event('tool/result', 2, {
+      turn: 1,
+      message: { source: { kind: 'tool', callId }, content: [] },
+    })
+    const view = (forValue: 'call' | 'result', fileName: string) => ({
+      for: forValue,
+      view: { card: 'diff', diffs: [{ path: fileName, oldText: 'before', newText: 'after' }] },
+    })
 
-      manager.accept('session-case', cwd, call, view('call', 'CaseFile.ts'))
-      fs.writeFileSync(filePath, 'after\n')
-      expect(manager.accept('session-case', cwd, result, view('result', 'casefile.ts'))).toBe(true)
-      expect(manager.changedFiles('session-case')).toEqual([{
-        turn: 1,
-        files: [{ path: 'CaseFile.ts', additions: 1, deletions: 1, canRevert: true }],
-      }])
-      expect(manager.revertFile('session-case', cwd, 'casefile.ts', 1)).toEqual([])
-      expect(fs.readFileSync(filePath, 'utf8')).toBe('before\n')
-    },
-  )
+    manager.accept('session-case', cwd, call, view('call', 'CaseFile.ts'))
+    fs.writeFileSync(filePath, 'after\n')
+    expect(manager.accept('session-case', cwd, result, view('result', 'casefile.ts'))).toBe(true)
+    expect(manager.changedFiles('session-case')).toEqual([{
+      turn: 1,
+      files: [{ path: 'CaseFile.ts', additions: 1, deletions: 1, canRevert: true }],
+    }])
+    expect(manager.revertFile('session-case', cwd, 'casefile.ts', 1)).toEqual([])
+    expect(fs.readFileSync(filePath, 'utf8')).toBe('before\n')
+  })
+
+  it('keeps differently cased files separate on a case-sensitive filesystem', () => {
+    const cwd = temporaryWorkspace()
+    const upperPath = path.join(cwd, 'App.ts')
+    const lowerPath = path.join(cwd, 'app.ts')
+    fs.writeFileSync(upperPath, 'upper-before\n')
+    fs.writeFileSync(lowerPath, 'lower-before\n')
+    if (fs.readFileSync(upperPath, 'utf8') !== 'upper-before\n') return
+
+    const manager = new DiffReviewManager()
+    const callId = 'case-sensitive-paths'
+    const diffs = [
+      { path: 'App.ts', oldText: 'upper-before', newText: 'upper-after' },
+      { path: 'app.ts', oldText: 'lower-before', newText: 'lower-after' },
+    ]
+    manager.accept(
+      'session-sensitive',
+      cwd,
+      event('tool/call', 1, { turn: 1, callId, name: 'edit' }),
+      { for: 'call', view: { card: 'diff', diffs } },
+    )
+    fs.writeFileSync(upperPath, 'upper-after\n')
+    fs.writeFileSync(lowerPath, 'lower-after\n')
+    expect(manager.accept(
+      'session-sensitive',
+      cwd,
+      event('tool/result', 2, { turn: 1, message: { source: { kind: 'tool', callId }, content: [] } }),
+      { for: 'result', view: { card: 'diff', diffs } },
+    )).toBe(true)
+
+    expect(manager.changedFiles('session-sensitive')).toEqual([{
+      turn: 1,
+      files: [
+        { path: 'App.ts', additions: 1, deletions: 1, canRevert: true },
+        { path: 'app.ts', additions: 1, deletions: 1, canRevert: true },
+      ],
+    }])
+    expect(manager.revertAll('session-sensitive')).toEqual([])
+    expect(fs.readFileSync(upperPath, 'utf8')).toBe('upper-before\n')
+    expect(fs.readFileSync(lowerPath, 'utf8')).toBe('lower-before\n')
+  })
 
   it('prepends older review history without losing reversible live snapshots', () => {
     const cwd = temporaryWorkspace()

--- a/tests/diff-review.spec.ts
+++ b/tests/diff-review.spec.ts
@@ -131,6 +131,36 @@ describe('DiffReviewManager', () => {
     expect(fs.readFileSync(filePath, 'utf8')).toBe('const value = 1\n')
   })
 
+  it.runIf(process.platform === 'win32' || process.platform === 'darwin')(
+    'treats differently cased diff paths as the same file',
+    () => {
+      const cwd = temporaryWorkspace()
+      const filePath = path.join(cwd, 'CaseFile.ts')
+      fs.writeFileSync(filePath, 'before\n')
+      const manager = new DiffReviewManager()
+      const callId = 'case-insensitive-path'
+      const call = event('tool/call', 1, { turn: 1, callId, name: 'edit' })
+      const result = event('tool/result', 2, {
+        turn: 1,
+        message: { source: { kind: 'tool', callId }, content: [] },
+      })
+      const view = (forValue: 'call' | 'result', fileName: string) => ({
+        for: forValue,
+        view: { card: 'diff', diffs: [{ path: fileName, oldText: 'before', newText: 'after' }] },
+      })
+
+      manager.accept('session-case', cwd, call, view('call', 'CaseFile.ts'))
+      fs.writeFileSync(filePath, 'after\n')
+      expect(manager.accept('session-case', cwd, result, view('result', 'casefile.ts'))).toBe(true)
+      expect(manager.changedFiles('session-case')).toEqual([{
+        turn: 1,
+        files: [{ path: 'CaseFile.ts', additions: 1, deletions: 1, canRevert: true }],
+      }])
+      expect(manager.revertFile('session-case', cwd, 'casefile.ts', 1)).toEqual([])
+      expect(fs.readFileSync(filePath, 'utf8')).toBe('before\n')
+    },
+  )
+
   it('prepends older review history without losing reversible live snapshots', () => {
     const cwd = temporaryWorkspace()
     const filePath = path.join(cwd, 'current.ts')

--- a/tests/diff-review.spec.ts
+++ b/tests/diff-review.spec.ts
@@ -44,6 +44,7 @@ describe('DiffReviewManager', () => {
 
   it('rebuilds changed files from official DSH diff views and opens a native diff', async () => {
     const manager = new DiffReviewManager()
+    const displayPath = path.join('src', 'app.ts')
     const changed = manager.rebuild('session-1', '/workspace', [
       {
         event: event('tool/call', 1, { turn: 1, step: 1, callId: 'call-1', name: 'edit', arguments: '{}' }),
@@ -68,13 +69,13 @@ describe('DiffReviewManager', () => {
       },
     ])
 
-    expect(changed).toEqual([{ turn: 1, files: [{ path: 'src/app.ts', additions: 1, deletions: 1, canRevert: false }] }])
+    expect(changed).toEqual([{ turn: 1, files: [{ path: displayPath, additions: 1, deletions: 1, canRevert: false }] }])
     await manager.reviewFile('session-1', '/workspace', 'src/app.ts')
     expect(mocks.executeCommand).toHaveBeenCalledWith(
       'vscode.diff',
       expect.objectContaining({ scheme: 'dsh-diff', authority: 'before' }),
       expect.objectContaining({ scheme: 'dsh-diff', authority: 'after' }),
-      'src/app.ts — DeepSeek changes (Turn 1)',
+      `${displayPath} — DeepSeek changes (Turn 1)`,
       { preview: true },
     )
   })
@@ -123,7 +124,7 @@ describe('DiffReviewManager', () => {
     expect(manager.accept('session-live', cwd, result, resultView)).toBe(true)
     expect(manager.changedFiles('session-live')).toEqual([{
       turn: 2,
-      files: [{ path: 'src/app.ts', additions: 1, deletions: 1, canRevert: true }],
+      files: [{ path: path.join('src', 'app.ts'), additions: 1, deletions: 1, canRevert: true }],
     }])
 
     expect(manager.revertFile('session-live', cwd, 'src/app.ts', 2)).toEqual([])

--- a/tests/dirty-file-guard.spec.ts
+++ b/tests/dirty-file-guard.spec.ts
@@ -1,16 +1,49 @@
-import { describe, expect, it } from 'vitest'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 import { comparableFilePath } from '../src/file-path.ts'
 
 describe('comparableFilePath', () => {
-  it('compares Windows paths without case sensitivity', () => {
-    expect(comparableFilePath('C:\\Repo\\App.ts', 'win32')).toBe(
-      comparableFilePath('c:\\repo\\app.ts', 'win32'),
-    )
+  const temporaryDirectories: string[] = []
+  afterEach(() => {
+    for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true })
   })
 
-  it('preserves case on case-sensitive platforms', () => {
-    expect(comparableFilePath('/repo/App.ts', 'linux')).not.toBe(
-      comparableFilePath('/repo/app.ts', 'linux'),
+  function temporaryDirectory(): string {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'dsh-vscode-path-'))
+    temporaryDirectories.push(directory)
+    return directory
+  }
+
+  it('uses the real filesystem identity for differently cased aliases', () => {
+    const directory = temporaryDirectory()
+    const actual = path.join(directory, 'MixedCase.ts')
+    const alias = path.join(directory, 'mixedcase.ts')
+    fs.writeFileSync(actual, '')
+
+    if (fs.existsSync(alias)) {
+      expect(comparableFilePath(alias)).toBe(comparableFilePath(actual))
+    } else {
+      expect(comparableFilePath(alias)).not.toBe(comparableFilePath(actual))
+    }
+  })
+
+  it('preserves distinct files on a case-sensitive filesystem', () => {
+    const directory = temporaryDirectory()
+    const upper = path.join(directory, 'App.ts')
+    const lower = path.join(directory, 'app.ts')
+    fs.writeFileSync(upper, 'upper')
+    fs.writeFileSync(lower, 'lower')
+    if (fs.readFileSync(upper, 'utf8') !== 'upper') return
+
+    expect(comparableFilePath(upper)).not.toBe(comparableFilePath(lower))
+  })
+
+  it('does not fold the case of paths that do not exist yet', () => {
+    const directory = temporaryDirectory()
+    expect(comparableFilePath(path.join(directory, 'Future.ts'))).not.toBe(
+      comparableFilePath(path.join(directory, 'future.ts')),
     )
   })
 })

--- a/tests/dirty-file-guard.spec.ts
+++ b/tests/dirty-file-guard.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { comparableFilePath } from '../src/file-path.ts'
+
+describe('comparableFilePath', () => {
+  it('compares Windows paths without case sensitivity', () => {
+    expect(comparableFilePath('C:\\Repo\\App.ts', 'win32')).toBe(
+      comparableFilePath('c:\\repo\\app.ts', 'win32'),
+    )
+  })
+
+  it('preserves case on case-sensitive platforms', () => {
+    expect(comparableFilePath('/repo/App.ts', 'linux')).not.toBe(
+      comparableFilePath('/repo/app.ts', 'linux'),
+    )
+  })
+})

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -177,6 +177,11 @@ describe('DSH launch resolution', () => {
       'right>captured.txt',
       '(group)',
       'caret^value',
+      'percent%PATH%value',
+      'bang!value',
+      'quote"value',
+      'trailing\\',
+      '',
     ]
     const launch = resolveLaunch('/not/a/source/tree', shim, unsafeLooking, {
       platform: 'win32',

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
 import { describe, expect, it } from 'vitest'
 import { findSourceRoot, parseDshWebUrl, resolveLaunch, webArgsForDshVersion } from '../src/launch.ts'
 
@@ -82,8 +83,9 @@ describe('DSH launch resolution', () => {
       env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
     })).toEqual({
       command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/c', 'dsh', 'web'],
+      args: ['/d', '/s', '/c', '"dsh ^"web^""'],
       sourceCheckout: false,
+      windowsVerbatimArguments: true,
     })
   })
 
@@ -109,6 +111,86 @@ describe('DSH launch resolution', () => {
       args: [entry, 'web'],
       sourceCheckout: false,
     })
+  })
+
+  it('preserves the first PATH match instead of skipping an earlier dsh.exe', () => {
+    const nativePrefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-native-'))
+    const npmPrefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-npm-'))
+    const native = join(nativePrefix, 'dsh.exe')
+    const packageRoot = join(npmPrefix, 'node_modules', '@deepseek-ai', 'dsh')
+    mkdirSync(join(packageRoot, 'lib'), { recursive: true })
+    writeFileSync(native, '')
+    writeFileSync(join(npmPrefix, 'dsh.cmd'), '@echo off\r\n')
+    writeFileSync(join(npmPrefix, 'node.exe'), '')
+    writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh',
+      bin: { dsh: 'lib/bin.js' },
+    }))
+    writeFileSync(join(packageRoot, 'lib', 'bin.js'), '')
+
+    expect(resolveLaunch('/not/a/source/tree', 'dsh', ['web'], {
+      platform: 'win32',
+      env: { Path: `${nativePrefix};${npmPrefix}`, PATHEXT: '.EXE;.CMD' },
+    })).toEqual({
+      command: native,
+      args: ['web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('resolves the current directory before PATH like cmd.exe', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-cwd-'))
+    const pathPrefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-path-'))
+    const local = join(workspace, 'dsh.exe')
+    writeFileSync(local, '')
+    writeFileSync(join(pathPrefix, 'dsh.exe'), '')
+
+    expect(resolveLaunch('/not/a/source/tree', 'dsh', ['web'], {
+      platform: 'win32',
+      cwd: workspace,
+      env: { Path: pathPrefix, PATHEXT: '.EXE' },
+    })).toEqual({
+      command: local,
+      args: ['web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('rejects newline injection before building a cmd.exe fallback', () => {
+    expect(() => resolveLaunch('/not/a/source/tree', 'dsh', ['safe\r\necho injected'], {
+      platform: 'win32',
+      env: { Path: '', ComSpec: 'cmd.exe' },
+    })).toThrow('cannot contain NUL or newline')
+  })
+
+  it.runIf(process.platform === 'win32')('preserves cmd.exe metacharacters as literal arguments', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-shell-'))
+    const shim = join(prefix, 'dsh.cmd')
+    const capture = join(prefix, 'capture.cjs')
+    writeFileSync(capture, 'process.stdout.write(JSON.stringify(process.argv.slice(2)))\n')
+    writeFileSync(shim, `@echo off\r\n"${process.execPath}" "%~dp0capture.cjs" %*\r\n`)
+    const unsafeLooking = [
+      'space value',
+      'value&echo SHOULD_NOT_RUN',
+      'pipe|findstr x',
+      'left<missing.txt',
+      'right>captured.txt',
+      '(group)',
+      'caret^value',
+    ]
+    const launch = resolveLaunch('/not/a/source/tree', shim, unsafeLooking, {
+      platform: 'win32',
+      env: process.env,
+    })
+    const result = spawnSync(launch.command, launch.args, {
+      encoding: 'utf8',
+      windowsHide: true,
+      windowsVerbatimArguments: launch.windowsVerbatimArguments,
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.status, result.stderr).toBe(0)
+    expect(JSON.parse(result.stdout)).toEqual(unsafeLooking)
   })
 
   it('launches an npm-installed DSH entry directly on Windows', () => {
@@ -167,9 +249,9 @@ describe('DSH launch resolution', () => {
       env: { Path: prefix, ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
     })).toEqual({
       command: 'C:\\Windows\\System32\\cmd.exe',
-      // Extensionless: PATHEXT resolution covers dsh.cmd and volta/scoop dsh.exe.
-      args: ['/c', 'dsh', 'web'],
+      args: ['/d', '/s', '/c', '"dsh ^"web^""'],
       sourceCheckout: false,
+      windowsVerbatimArguments: true,
     })
   })
 
@@ -180,8 +262,9 @@ describe('DSH launch resolution', () => {
       env: { Path: prefix },
     })).toEqual({
       command: 'cmd.exe',
-      args: ['/c', 'dsh', 'web'],
+      args: ['/d', '/s', '/c', '"dsh ^"web^""'],
       sourceCheckout: false,
+      windowsVerbatimArguments: true,
     })
   })
 
@@ -193,8 +276,9 @@ describe('DSH launch resolution', () => {
       env: { ComSpec: 'cmd.exe' },
     })).toEqual({
       command: 'cmd.exe',
-      args: ['/c', join(prefix, 'tools', 'dsh.cmd'), 'web'],
+      args: ['/d', '/s', '/c', `"${join(prefix, 'tools', 'dsh.cmd')} ^"web^""`],
       sourceCheckout: false,
+      windowsVerbatimArguments: true,
     })
   })
 
@@ -207,8 +291,9 @@ describe('DSH launch resolution', () => {
       env: { ComSpec: 'cmd.exe' },
     })).toEqual({
       command: 'cmd.exe',
-      args: ['/c', cmdPath, 'web'],
+      args: ['/d', '/s', '/c', `"${cmdPath} ^"web^""`],
       sourceCheckout: false,
+      windowsVerbatimArguments: true,
     })
   })
 

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -61,7 +61,7 @@ describe('DSH launch resolution', () => {
   })
 
   it('honors an explicit executable without adding a mock or wrapper mode', () => {
-    expect(resolveLaunch('/not/a/source/tree', '/opt/dsh', ['web'])).toEqual({
+    expect(resolveLaunch('/not/a/source/tree', '/opt/dsh', ['web'], { platform: 'linux' })).toEqual({
       command: '/opt/dsh',
       args: ['web'],
       sourceCheckout: false,

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -171,6 +171,7 @@ describe('DSH launch resolution', () => {
     writeFileSync(shim, `@echo off\r\n"${process.execPath}" "%~dp0capture.cjs" %*\r\n`)
     const unsafeLooking = [
       'space value',
+      'tab\tvalue',
       'value&echo SHOULD_NOT_RUN',
       'pipe|findstr x',
       'left<missing.txt',

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -138,6 +138,24 @@ describe('DSH launch resolution', () => {
     })
   })
 
+  it('routes non-native PATHEXT matches through cmd.exe', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-script-'))
+    const script = join(prefix, 'dsh.js')
+    writeFileSync(script, '')
+
+    const launch = resolveLaunch('/not/a/source/tree', 'dsh', ['web'], {
+      platform: 'win32',
+      env: { Path: prefix, PATHEXT: '.JS;.EXE', ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    })
+
+    expect(launch).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', `"${script} ^"web^""`],
+      sourceCheckout: false,
+      windowsVerbatimArguments: true,
+    })
+  })
+
   it('resolves the current directory before PATH like cmd.exe', () => {
     const workspace = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-cwd-'))
     const pathPrefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-path-'))

--- a/tests/launch.spec.ts
+++ b/tests/launch.spec.ts
@@ -69,9 +69,44 @@ describe('DSH launch resolution', () => {
 
   it('falls back to the installed DSH executable outside a source checkout', () => {
     const root = mkdtempSync(join(tmpdir(), 'dsh-vscode-installed-'))
-    expect(resolveLaunch(root, '', ['web'])).toEqual({
-      command: process.platform === 'win32' ? 'dsh.cmd' : 'dsh',
+    expect(resolveLaunch(root, '', ['web'], { platform: 'linux' })).toEqual({
+      command: 'dsh',
       args: ['web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('routes an explicitly configured dsh command through cmd.exe on Windows', () => {
+    expect(resolveLaunch('/not/a/source/tree', 'dsh', ['web'], {
+      platform: 'win32',
+      env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+    })).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/c', 'dsh', 'web'],
+      sourceCheckout: false,
+    })
+  })
+
+  it('resolves an explicitly configured npm dsh command from PATH on Windows', () => {
+    const prefix = mkdtempSync(join(tmpdir(), 'dsh-vscode-windows-explicit-name-'))
+    const packageRoot = join(prefix, 'node_modules', '@deepseek-ai', 'dsh')
+    const entry = join(packageRoot, 'lib', 'bin.js')
+    const node = join(prefix, 'node.exe')
+    mkdirSync(join(packageRoot, 'lib'), { recursive: true })
+    writeFileSync(join(prefix, 'dsh.cmd'), '@echo off\r\n')
+    writeFileSync(node, '')
+    writeFileSync(join(packageRoot, 'package.json'), JSON.stringify({
+      name: '@deepseek-ai/dsh',
+      bin: { dsh: 'lib/bin.js' },
+    }))
+    writeFileSync(entry, '')
+
+    expect(resolveLaunch('/not/a/source/tree', 'dsh', ['web'], {
+      platform: 'win32',
+      env: { Path: prefix },
+    })).toEqual({
+      command: node,
+      args: [entry, 'web'],
       sourceCheckout: false,
     })
   })

--- a/tests/plugin-profile.spec.ts
+++ b/tests/plugin-profile.spec.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { join, parse } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   findAddedPlugin,
@@ -13,9 +13,12 @@ import {
 
 describe('DSH web profile plugins', () => {
   it('resolves the official DSH home convention', () => {
-    expect(resolveDshHome({}, '/Users/example')).toBe('/Users/example/.dsh')
-    expect(resolveDshHome({ DSH_HOME: '~/custom-dsh' }, '/Users/example')).toBe('/Users/example/custom-dsh')
-    expect(resolveDshHome({ DSH_HOME: '/tmp/dsh-home' }, '/Users/example')).toBe('/tmp/dsh-home')
+    const root = parse(process.cwd()).root
+    const userHome = join(root, 'Users', 'example')
+    const configuredHome = join(root, 'tmp', 'dsh-home')
+    expect(resolveDshHome({}, userHome)).toBe(join(userHome, '.dsh'))
+    expect(resolveDshHome({ DSH_HOME: '~/custom-dsh' }, userHome)).toBe(join(userHome, 'custom-dsh'))
+    expect(resolveDshHome({ DSH_HOME: configuredHome }, userHome)).toBe(configuredHome)
   })
 
   it('reads dependencies and marks only declared profile bundles as active candidates', () => {

--- a/tests/process-tree.spec.ts
+++ b/tests/process-tree.spec.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import { terminateProcessTree } from '../src/process-tree.ts'
+
+function child(pid = 42) {
+  return {
+    pid,
+    exitCode: null,
+    signalCode: null,
+    kill: vi.fn(() => true),
+  }
+}
+
+describe('process tree termination', () => {
+  it('uses normal Node signals outside Windows', () => {
+    const process = child()
+    expect(terminateProcessTree(process, 'SIGTERM', { platform: 'linux' })).toBe(true)
+    expect(process.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('uses taskkill to terminate the complete Windows process tree', () => {
+    const process = child(1234)
+    const taskkill = new EventEmitter()
+    const spawnProcess = vi.fn(() => taskkill)
+
+    expect(terminateProcessTree(process, 'SIGTERM', {
+      platform: 'win32',
+      spawnProcess: spawnProcess as never,
+    })).toBe(true)
+    expect(spawnProcess).toHaveBeenCalledWith(
+      'taskkill.exe',
+      ['/PID', '1234', '/T', '/F'],
+      { stdio: 'ignore', windowsHide: true },
+    )
+    expect(process.kill).not.toHaveBeenCalled()
+  })
+
+  it('falls back to killing the wrapper when taskkill fails', () => {
+    const process = child()
+    const taskkill = new EventEmitter()
+    const spawnProcess = vi.fn(() => taskkill)
+    terminateProcessTree(process, 'SIGTERM', {
+      platform: 'win32',
+      spawnProcess: spawnProcess as never,
+    })
+
+    taskkill.emit('close', 1)
+    expect(process.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+})

--- a/tests/process-tree.spec.ts
+++ b/tests/process-tree.spec.ts
@@ -26,9 +26,10 @@ describe('process tree termination', () => {
     expect(terminateProcessTree(process, 'SIGTERM', {
       platform: 'win32',
       spawnProcess: spawnProcess as never,
+      env: { SystemRoot: 'C:\\Windows' },
     })).toBe(true)
     expect(spawnProcess).toHaveBeenCalledWith(
-      'taskkill.exe',
+      'C:\\Windows\\System32\\taskkill.exe',
       ['/PID', '1234', '/T', '/F'],
       { stdio: 'ignore', windowsHide: true },
     )
@@ -42,9 +43,23 @@ describe('process tree termination', () => {
     terminateProcessTree(process, 'SIGTERM', {
       platform: 'win32',
       spawnProcess: spawnProcess as never,
+      env: { windir: 'C:\\Windows' },
     })
 
     taskkill.emit('close', 1)
+    expect(process.kill).toHaveBeenCalledWith('SIGKILL')
+  })
+
+  it('does not search the current directory when the Windows system root is unavailable', () => {
+    const process = child()
+    const spawnProcess = vi.fn()
+
+    expect(terminateProcessTree(process, 'SIGTERM', {
+      platform: 'win32',
+      spawnProcess: spawnProcess as never,
+      env: {},
+    })).toBe(true)
+    expect(spawnProcess).not.toHaveBeenCalled()
     expect(process.kill).toHaveBeenCalledWith('SIGKILL')
   })
 })

--- a/tests/tool-write-guard.spec.ts
+++ b/tests/tool-write-guard.spec.ts
@@ -1,3 +1,4 @@
+import * as path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { DshEvent } from '../src/conversation.js'
 import { absoluteToolPaths, toolWriteIntents } from '../src/tool-write-guard.js'
@@ -42,9 +43,12 @@ describe('toolWriteIntents', () => {
 
 describe('absoluteToolPaths', () => {
   it('resolves relative paths and preserves absolute paths', () => {
-    expect(absoluteToolPaths('/workspace/project', ['src/app.ts', '/shared/config.ts'])).toEqual([
-      '/workspace/project/src/app.ts',
-      '/shared/config.ts',
+    const root = path.parse(process.cwd()).root
+    const cwd = path.join(root, 'workspace', 'project')
+    const absolute = path.join(root, 'shared', 'config.ts')
+    expect(absoluteToolPaths(cwd, ['src/app.ts', absolute])).toEqual([
+      path.join(cwd, 'src', 'app.ts'),
+      absolute,
     ])
   })
 })


### PR DESCRIPTION
## Summary

- resolve an explicitly configured `dsh` command through the Windows npm shim or `cmd.exe` fallback
- terminate the complete Windows process tree when stopping DSH or cancelling plugin operations
- compare dirty-buffer paths using Windows case-insensitive filesystem semantics before reverting changes
- run CI on both Ubuntu and Windows

## Validation

- `pnpm run check`
- `pnpm run package`
- 154 tests passed