### PR TITLE
feat: add sidebar onboarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   ],
   "main": "./dist/extension.js",
   "activationEvents": [
+    "onStartupFinished",
     "onView:deepseekHarness.chat",
+    "onCommand:deepseekHarness.openChat",
     "onCommand:deepseekHarness.openInEditor",
     "onCommand:deepseekHarness.addSelection",
     "onCommand:deepseekHarness.fixWithDeepSeek",
@@ -73,6 +75,10 @@
       ]
     },
     "commands": [
+      {
+        "command": "deepseekHarness.openChat",
+        "title": "DeepSeek Harness: Open Chat"
+      },
       {
         "command": "deepseekHarness.openInEditor",
         "title": "DeepSeek Harness: Open Chat in Editor",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,7 @@ import { chatHtml } from './webview.js'
 import { DshPluginManager } from './plugin-manager.js'
 import type { PluginInventorySnapshot } from './plugin-profile.js'
 import type { SettingsDescription, SettingsMutation, SettingsNamespace } from './runtime-settings.js'
+import { setupKindFor, type SetupKind } from './setup-state.js'
 import { earliestHistorySequence, mergeHistoryEntries, unseenHistoryEntries } from './history.js'
 import { routeSlashInput, type SlashRoute } from './slash-routing.js'
 import { unavailableUsageMeterState, usageMeterStateOf, type UsageMeterState } from './usage-meter.js'
@@ -126,6 +127,7 @@ interface WorkspacePick extends vscode.QuickPickItem {
 interface ChatViewState {
   phase: 'loading' | 'ready' | 'error'
   statusText: string
+  setup: SetupKind
   workspaceName: string
   cwd: string
   sessions: SessionItem[]
@@ -182,15 +184,16 @@ function stateUpdateForWebview(update: ChatViewStateUpdate): ChatViewStateUpdate
 
 function initialState(cwd: string): ChatViewState {
   return {
-    phase: 'loading',
-    statusText: 'Starting the official DeepSeek Harness runtime…',
+    phase: cwd === '' ? 'error' : 'loading',
+    statusText: cwd === '' ? 'Open a project folder to start using DeepSeek Harness.' : 'Starting the official DeepSeek Harness runtime…',
+    setup: setupKindFor(cwd, cwd === '' ? 'error' : 'loading', ''),
     workspaceName: path.basename(cwd),
     cwd,
     sessions: [],
     sessionId: '',
     messages: [],
     running: false,
-    routable: true,
+    routable: cwd !== '',
     models: [],
     approval: null,
     question: null,
@@ -260,10 +263,14 @@ class DshChatController implements vscode.Disposable {
   }
 
   observeRuntime(state: RuntimeState): void {
-    if (state.kind === 'starting') this.publish({ phase: 'loading', statusText: state.detail })
-    if (state.kind === 'failed') this.publish({ phase: 'error', statusText: state.message })
+    if (state.kind === 'starting') this.publish({ phase: 'loading', statusText: state.detail, setup: null })
+    if (state.kind === 'failed') this.publish({
+      phase: 'error',
+      statusText: state.message,
+      setup: setupKindFor(this.cwd, 'error', state.message),
+    })
     if (state.kind === 'stopped' && this._state.phase === 'ready') {
-      this.publish({ phase: 'error', statusText: 'DeepSeek Harness stopped.' })
+      this.publish({ phase: 'error', statusText: 'DeepSeek Harness stopped.', setup: null })
     }
   }
 
@@ -279,12 +286,14 @@ class DshChatController implements vscode.Disposable {
     this.jobsBySession.clear()
     this.historyEntries = []
     this.publish({
-      phase: 'loading',
-      statusText: 'Starting the official DeepSeek Harness runtime…',
+      phase: this.cwd === '' ? 'error' : 'loading',
+      statusText: this.cwd === '' ? 'Open a project folder to start using DeepSeek Harness.' : 'Starting the official DeepSeek Harness runtime…',
+      setup: this.cwd === '' ? 'workspace' : null,
       messages: [],
       sessions: [],
       sessionId: '',
       running: false,
+      routable: this.cwd !== '',
       models: [],
       approval: null,
       question: null,
@@ -300,6 +309,7 @@ class DshChatController implements vscode.Disposable {
       hasMoreHistory: false,
       loadingHistory: false,
     })
+    if (this.cwd === '') return
     try {
       const uri = await this.runtime.start(this.cwd === '' ? undefined : vscode.Uri.file(this.cwd))
       if (generation !== this.generation) return
@@ -325,7 +335,7 @@ class DshChatController implements vscode.Disposable {
       if (generation !== this.generation) return
       const message = error instanceof Error ? error.message : String(error)
       this.output.appendLine(`[chat] ${message}`)
-      this.publish({ phase: 'error', statusText: message })
+      this.publish({ phase: 'error', statusText: message, setup: setupKindFor(this.cwd, 'error', message) })
     }
   }
 
@@ -601,6 +611,7 @@ class DshChatController implements vscode.Disposable {
     this.publish({
       phase: 'ready',
       statusText: '',
+      setup: null,
       sessionId,
       messages: this.projectedMessages(),
       running: summary?.running ?? false,
@@ -1026,6 +1037,7 @@ class DshSurface implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[]
   private readonly draftImages: Array<PromptImage & { id: string }> = []
   private ready = false
+  private pendingFocus = false
   private pendingPrompt: string | undefined
   private pendingState: ChatViewState | undefined
   private postedState: ChatViewState | undefined
@@ -1050,6 +1062,10 @@ class DshSurface implements vscode.Disposable {
   }
 
   focusPrompt(): void {
+    if (!this.ready) {
+      this.pendingFocus = true
+      return
+    }
     void this.webview.postMessage({ type: 'focus-prompt' })
   }
 
@@ -1213,6 +1229,10 @@ class DshSurface implements vscode.Disposable {
           this.ready = true
           await this.resyncState()
           await this.webview.postMessage({ type: 'ide-context', state: this.editorContext.viewState() })
+          if (this.pendingFocus) {
+            this.pendingFocus = false
+            await this.webview.postMessage({ type: 'focus-prompt' })
+          }
           if (this.pendingPrompt !== undefined) {
             await this.webview.postMessage({ type: 'set-prompt', text: this.pendingPrompt })
             this.pendingPrompt = undefined
@@ -1220,6 +1240,10 @@ class DshSurface implements vscode.Disposable {
           return
         case 'restart': await this.controller.restart(); return
         case 'output': this.output.show(true); return
+        case 'open-workspace': await this.chooseWorkspace(); return
+        case 'configure-api-key':
+          await vscode.commands.executeCommand('deepseekHarness.configureApiKey')
+          return
         case 'new-session': await this.controller.newSession(); return
         case 'select-session':
           if (typeof value.sessionId === 'string') await this.controller.selectSession(value.sessionId)
@@ -1447,6 +1471,7 @@ function imageMediaType(filePath: string): ImageMediaType | undefined {
 class DshViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   private surface: DshSurface | undefined
   private pendingPrompt: string | undefined
+  private pendingFocus = false
 
   constructor(
     private readonly controller: DshChatController,
@@ -1459,6 +1484,10 @@ class DshViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
     this.surface?.dispose()
     const surface = new DshSurface(view.webview, this.controller, this.output, this.editorContext, this.extensionUri)
     this.surface = surface
+    if (this.pendingFocus) {
+      this.pendingFocus = false
+      surface.focusPrompt()
+    }
     if (this.pendingPrompt !== undefined) {
       surface.setPrompt(this.pendingPrompt)
       this.pendingPrompt = undefined
@@ -1476,7 +1505,11 @@ class DshViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   }
 
   focusPrompt(): void {
-    this.surface?.focusPrompt()
+    if (this.surface === undefined) {
+      this.pendingFocus = true
+      return
+    }
+    this.surface.focusPrompt()
   }
 
   setPrompt(text: string): void {
@@ -1580,6 +1613,13 @@ export function activate(context: vscode.ExtensionContext): void {
     provider,
     { webviewOptions: { retainContextWhenHidden: true } },
   ))
+
+  const openChat = async (): Promise<void> => {
+    await vscode.commands.executeCommand('workbench.view.extension.deepseekHarness')
+    provider.focusPrompt()
+  }
+
+  context.subscriptions.push(vscode.commands.registerCommand('deepseekHarness.openChat', openChat))
 
   context.subscriptions.push(vscode.commands.registerCommand('deepseekHarness.openInEditor', async () => {
     const panel = vscode.window.createWebviewPanel(
@@ -1738,6 +1778,22 @@ export function activate(context: vscode.ExtensionContext): void {
     await controller.restart()
     void vscode.window.showInformationMessage('Stored DeepSeek API key removed. DeepSeek Harness restarted.')
   }))
+
+  const welcomeKey = 'deepseekHarness.welcome.openChat.v1'
+  if (workspace !== undefined && context.globalState.get<boolean>(welcomeKey) !== true) {
+    void (async () => {
+      try {
+        await context.globalState.update(welcomeKey, true)
+        const choice = await vscode.window.showInformationMessage(
+          'DSH Sidebar is ready in VS Code’s right sidebar.',
+          'Open DSH Sidebar',
+        )
+        if (choice === 'Open DSH Sidebar') await openChat()
+      } catch (error) {
+        output.appendLine(`[onboarding] ${error instanceof Error ? error.message : String(error)}`)
+      }
+    })()
+  }
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/setup-state.ts
+++ b/src/setup-state.ts
@@ -1,0 +1,15 @@
+export type SetupKind = 'workspace' | 'dsh' | 'api-key' | null
+
+type ChatPhase = 'loading' | 'ready' | 'error'
+
+const MISSING_DSH = /(?:spawn(?:sync)?\s+dsh(?:\.cmd)?\s+enoent|enoent[^\n]*\bdsh(?:\.cmd)?\b|\bdsh(?:\.cmd)?\b[^\n]*(?:not found|not recognized)|could not (?:find|launch|start)[^\n]*\bdsh\b)/i
+const MISSING_API_KEY = /(?:deepseek_api_key|api key|unauthori[sz]ed|authentication (?:failed|required)|invalid (?:credential|token))/i
+
+/** Maps startup failures to the next useful setup action without hiding the original error. */
+export function setupKindFor(cwd: string, phase: ChatPhase, statusText: string): SetupKind {
+  if (cwd.trim() === '') return 'workspace'
+  if (phase !== 'error') return null
+  if (MISSING_DSH.test(statusText)) return 'dsh'
+  if (MISSING_API_KEY.test(statusText)) return 'api-key'
+  return null
+}

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -136,6 +136,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     .status, .interaction { margin: 10px 0; padding: 11px; border: 1px solid var(--vscode-widget-border); border-radius: 8px; overflow-wrap: anywhere; background: var(--vscode-editor-background); }
     .status { color: var(--vscode-descriptionForeground); border: 0; background: var(--vscode-textBlockQuote-background); }
     .status.error { color: var(--vscode-errorForeground); }
+    .status.setup { padding: 15px; color: var(--vscode-foreground); border: 1px solid var(--vscode-widget-border); border-radius: 10px; background: var(--vscode-editor-background); }
+    .setup-title { margin-bottom: 4px; font-weight: 600; }
+    .setup-detail { color: var(--vscode-descriptionForeground); }
     .interaction-title { margin-bottom: 4px; font-weight: 600; }
     .interaction-detail, .question-detail { color: var(--vscode-descriptionForeground); font-size: 12px; }
     .actions { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 10px; }
@@ -839,12 +842,30 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       while (cursor) { const next = cursor.nextSibling; cursor.remove(); cursor = next; }
     }
     function renderStatus(current) {
-      const box = node('div', 'status' + (current.phase === 'error' ? ' error' : ''), current.statusText || 'Starting DeepSeek Harness…');
+      const setup = current.setup;
+      const box = node('div', 'status' + (setup ? ' setup' : (current.phase === 'error' ? ' error' : '')));
+      if (setup === 'workspace') {
+        box.append(node('div', 'setup-title', 'Open a project to get started'), node('div', 'setup-detail', 'DeepSeek Harness works inside a trusted VS Code project folder.'));
+      } else if (setup === 'dsh') {
+        box.append(node('div', 'setup-title', 'Install DeepSeek Harness'), node('div', 'setup-detail', current.statusText || 'The dsh executable was not found.'));
+      } else if (setup === 'api-key') {
+        box.append(node('div', 'setup-title', 'Configure your DeepSeek API key'), node('div', 'setup-detail', current.statusText || 'DeepSeek Harness needs an API key before it can run tasks.'));
+      } else {
+        box.append(document.createTextNode(current.statusText || 'Starting DeepSeek Harness…'));
+      }
       if (current.phase === 'error') {
         const actions = node('div', 'actions');
-        const retry = node('button', 'secondary', 'Reconnect'); const output = node('button', 'secondary', 'Show output');
-        retry.addEventListener('click', () => vscode.postMessage({ type: 'restart' })); output.addEventListener('click', () => vscode.postMessage({ type: 'output' }));
-        actions.append(retry, output); box.append(actions);
+        if (setup === 'workspace') {
+          const open = node('button', 'primary', 'Open Project'); open.addEventListener('click', () => vscode.postMessage({ type: 'open-workspace' })); actions.append(open);
+        } else if (setup === 'dsh') {
+          const install = node('button', 'primary', 'View Installation'); install.addEventListener('click', () => vscode.postMessage({ type: 'open-link', href: 'https://github.com/deepseek-ai/deepseek-harness' })); actions.append(install);
+        } else if (setup === 'api-key') {
+          const configure = node('button', 'primary', 'Configure API Key'); configure.addEventListener('click', () => vscode.postMessage({ type: 'configure-api-key' })); actions.append(configure);
+        } else {
+          const retry = node('button', 'secondary', 'Reconnect'); retry.addEventListener('click', () => vscode.postMessage({ type: 'restart' })); actions.append(retry);
+        }
+        if (setup !== 'workspace') { const output = node('button', 'secondary', 'Show Output'); output.addEventListener('click', () => vscode.postMessage({ type: 'output' })); actions.append(output); }
+        box.append(actions);
       }
       return box;
     }
@@ -1330,7 +1351,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         for (const request of loadingToolRequests.values()) clearTimeout(request.timer);
         loadingToolRequests.clear(); toolOutputErrors.clear(); toolOutputPages.clear(); deferredOutputViews.clear(); pendingMessageAppends.clear();
       }
-      const statusKey = current.phase + '::' + current.statusText;
+      const statusKey = current.phase + '::' + current.statusText + '::' + current.setup;
       if (statusKey !== renderedStatusKey) {
         renderedStatusKey = statusKey;
         elements.conversationStatus.replaceChildren();

--- a/tests/setup-state.spec.ts
+++ b/tests/setup-state.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { setupKindFor } from '../src/setup-state.ts'
+
+describe('setup state', () => {
+  it('asks for a workspace before attempting runtime setup', () => {
+    expect(setupKindFor('', 'error', 'spawn dsh ENOENT')).toBe('workspace')
+  })
+
+  it('recognizes common missing DSH launch errors', () => {
+    expect(setupKindFor('/workspace', 'error', 'spawn dsh ENOENT')).toBe('dsh')
+    expect(setupKindFor('/workspace', 'error', 'dsh is not recognized as an internal command')).toBe('dsh')
+  })
+
+  it('recognizes credential errors without overriding healthy states', () => {
+    expect(setupKindFor('/workspace', 'error', 'DEEPSEEK_API_KEY is required')).toBe('api-key')
+    expect(setupKindFor('/workspace', 'ready', 'API key is required')).toBeNull()
+  })
+
+  it('leaves unrelated runtime failures on the generic recovery path', () => {
+    expect(setupKindFor('/workspace', 'error', 'Lost the DSH event stream')).toBeNull()
+  })
+})

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -22,6 +22,18 @@ describe('chat webview', () => {
     expect(html).toContain("href: 'https://github.com/Lixxx1/dsh-vscode'")
   })
 
+  it('offers actionable setup states instead of a generic reconnect loop', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const html = chatHtml(webview, mark)
+
+    expect(html).toContain('Open a project to get started')
+    expect(html).toContain("type: 'open-workspace'")
+    expect(html).toContain('Install DeepSeek Harness')
+    expect(html).toContain('https://github.com/deepseek-ai/deepseek-harness')
+    expect(html).toContain("type: 'configure-api-key'")
+  })
+
   it('uses append-only output and streaming paths', () => {
     const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
     const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri


### PR DESCRIPTION
## Summary

- add a command to open and focus the DSH sidebar
- show a one-time welcome action after installation
- provide actionable setup states for missing workspace, DSH, or API key
- preserve prompt focus while the webview is still loading

## Verification

- `npm run check`
- `npm run package`
- 168 tests passed, 1 skipped