### PR TITLE
feat: add a searchable session center

### DIFF
--- a/src/dsh-client.ts
+++ b/src/dsh-client.ts
@@ -154,6 +154,18 @@ export class DshClient {
     return this.call('session.list', {})
   }
 
+  listWorkspaces(): Promise<{ archivedSessionIds?: string[] }> {
+    return this.call('workspace.list', {})
+  }
+
+  renameSession(sessionId: string, title: string): Promise<{ title: string; seq?: number }> {
+    return this.call('session.rename', { sessionId, title })
+  }
+
+  archiveSession(sessionId: string): Promise<{ archivedSessionIds: string[] }> {
+    return this.call('workspace.archiveSession', { sessionId })
+  }
+
   createSession(cwd: string): Promise<{ sessionId: string; agentPreset?: string }> {
     return this.call('session.create', { cwd })
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1307,6 +1307,14 @@ class DshSurface implements vscode.Disposable {
     })
   }
 
+  private async restoreDraft(sessionId: string, requestId: number, text: string): Promise<void> {
+    await this.webview.postMessage({ type: 'restore-draft', sessionId, requestId, text })
+  }
+
+  private async acknowledgeDraft(sessionId: string, requestId: number): Promise<void> {
+    await this.webview.postMessage({ type: 'draft-sent', sessionId, requestId })
+  }
+
   private acceptMessage(message: unknown): void {
     if (typeof message !== 'object' || message === null || !('type' in message)) return
     const value = message as Record<string, unknown>
@@ -1398,8 +1406,15 @@ class DshSurface implements vscode.Disposable {
           return
         case 'send':
           if (typeof value.text === 'string') {
-            const sessionId = this.controller.state.sessionId
-            if (sessionId === '') return
+            const sessionId = typeof value.sessionId === 'string' ? value.sessionId : ''
+            const requestId = typeof value.requestId === 'number' && Number.isSafeInteger(value.requestId)
+              ? value.requestId
+              : -1
+            if (sessionId === '' || requestId < 0) return
+            if (this.controller.state.sessionId !== sessionId) {
+              await this.restoreDraft(sessionId, requestId, value.text)
+              return
+            }
             const draftImages = this.draftImagesFor(sessionId)
             if (value.text.trim() === '/permission danger-full-access') {
               const confirmed = await vscode.window.showWarningMessage(
@@ -1410,11 +1425,24 @@ class DshSurface implements vscode.Disposable {
                 },
                 'Enable Full Access',
               )
-              if (confirmed !== 'Enable Full Access') return
+              if (confirmed !== 'Enable Full Access') {
+                await this.restoreDraft(sessionId, requestId, value.text)
+                return
+              }
             }
             const slash = this.controller.slashRoute(value.text)
             const carriesIdeContext = slash.kind === 'prompt'
-            const ideContext = carriesIdeContext ? await this.editorContext.snapshotForPrompt(value.text) : undefined
+            let ideContext: IdeContextSnapshot | undefined
+            try {
+              ideContext = carriesIdeContext ? await this.editorContext.snapshotForPrompt(value.text) : undefined
+            } catch (error) {
+              await this.restoreDraft(sessionId, requestId, value.text)
+              throw error
+            }
+            if (this.controller.state.sessionId !== sessionId) {
+              await this.restoreDraft(sessionId, requestId, value.text)
+              return
+            }
             const mode: PromptMode = value.mode === 'steer' ? 'steer' : 'queue'
             // Limits can land after the picker ran, so the send is the last point
             // where the whole draft can be measured against what the runtime states.
@@ -1425,11 +1453,20 @@ class DshSurface implements vscode.Disposable {
             )
             if (rejection !== undefined) {
               void vscode.window.showWarningMessage(rejection)
-              this.setPrompt(value.text)
+              await this.restoreDraft(sessionId, requestId, value.text)
               return
             }
-            if (this.controller.state.sessionId !== sessionId) return
-            await this.controller.send(value.text, draftImages, ideContext, mode)
+            if (this.controller.state.sessionId !== sessionId) {
+              await this.restoreDraft(sessionId, requestId, value.text)
+              return
+            }
+            try {
+              await this.controller.send(value.text, draftImages, ideContext, mode)
+            } catch (error) {
+              await this.restoreDraft(sessionId, requestId, value.text)
+              throw error
+            }
+            await this.acknowledgeDraft(sessionId, requestId)
             this.draftImagesBySession.delete(sessionId)
             if (carriesIdeContext) this.editorContext.clearPinned()
             await this.publishDraftImages(sessionId)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,13 +64,9 @@ import {
   messagesPatchForWebview,
   type ConversationMessagesPatch,
 } from './chat-state-patch.js'
+import { sessionItems, type SessionItem } from './session-center.js'
 
 let activeRuntime: DshRuntime | undefined
-
-interface SessionItem {
-  id: string
-  title: string
-}
 
 interface ReasoningEffortItem {
   id: string
@@ -212,11 +208,6 @@ function initialState(cwd: string): ChatViewState {
   }
 }
 
-function titleOf(summary: SessionSummary): string {
-  const value = summary.projections?.values?.title
-  return typeof value === 'string' && value.trim() !== '' ? value : 'New conversation'
-}
-
 class DshChatController implements vscode.Disposable {
   private readonly changes = new vscode.EventEmitter<ChatViewState>()
   private readonly projector = new ConversationProjector()
@@ -231,6 +222,10 @@ class DshChatController implements vscode.Disposable {
   private readonly attachmentLoads = new Map<string, Promise<void>>()
   private readonly jobsBySession = new Map<string, JobItem[]>()
   private historyEntries: HistoryEntry[] = []
+  private archivedSessionIds = new Set<string>()
+  private readonly unreadSessionIds: Set<string>
+
+  private static readonly unreadStorageKey = 'deepseekHarness.unreadSessions'
 
   readonly onDidChangeState = this.changes.event
 
@@ -239,9 +234,11 @@ class DshChatController implements vscode.Disposable {
     private readonly output: vscode.OutputChannel,
     private readonly dirtyFiles: DirtyFileGuard,
     private readonly diffReviews: DiffReviewManager,
+    private readonly workspaceState: vscode.Memento,
     private _cwd: string,
   ) {
     this._state = initialState(_cwd)
+    this.unreadSessionIds = new Set(workspaceState.get<string[]>(DshChatController.unreadStorageKey, []))
   }
 
   get cwd(): string {
@@ -368,8 +365,30 @@ class DshChatController implements vscode.Disposable {
   }
 
   async selectSession(sessionId: string): Promise<void> {
-    if (!this.summaries.some(summary => summary.sessionId === sessionId && summary.cwd === this.cwd)) return
+    if (!this.summaries.some(summary => summary.sessionId === sessionId && summary.cwd === this.cwd)
+      || this.archivedSessionIds.has(sessionId)) return
+    this.markRead(sessionId)
     await this.loadSession(sessionId)
+  }
+
+  async renameSession(sessionId: string, title: string): Promise<void> {
+    const summary = this.summaries.find(item => item.sessionId === sessionId)
+    const normalized = title.trim()
+    if (summary === undefined || summary.blank || normalized === '') return
+    const result = await this.requireClient().renameSession(sessionId, normalized)
+    summary.projections = { values: { ...summary.projections?.values, title: result.title } }
+    summary.updatedAt = Date.now()
+    this.publishSessionItems()
+  }
+
+  async archiveSession(sessionId: string): Promise<void> {
+    const summary = this.summaries.find(item => item.sessionId === sessionId)
+    if (summary === undefined || summary.blank) return
+    const result = await this.requireClient().archiveSession(sessionId)
+    this.archivedSessionIds = new Set(result.archivedSessionIds)
+    this.unreadSessionIds.delete(sessionId)
+    this.persistUnreadSessions()
+    await this.loadSessions()
   }
 
   async loadOlderHistory(): Promise<void> {
@@ -568,24 +587,64 @@ class DshChatController implements vscode.Disposable {
 
   private async loadSessions(preferredId?: string): Promise<void> {
     const client = this.requireClient()
-    const { items } = await client.listSessions()
+    const [{ items }] = await Promise.all([
+      client.listSessions(),
+      this.refreshArchivedSessions(client),
+    ])
     this.summaries = items.filter(summary => summary.cwd === this.cwd && summary.origin !== 'subagent')
-    const currentStillExists = this.summaries.some(summary => summary.sessionId === this._state.sessionId)
-    const visible = this.summaries.filter(summary => !summary.blank || summary.sessionId === preferredId)
-    const selectedId = preferredId
-      ?? (currentStillExists ? this._state.sessionId : undefined)
-      ?? visible[0]?.sessionId
-      ?? this.summaries[0]?.sessionId
+    const selectable = this.summaries.filter(summary => !this.archivedSessionIds.has(summary.sessionId))
+    const preferredExists = preferredId === undefined
+      ? undefined
+      : selectable.some(summary => summary.sessionId === preferredId) ? preferredId : undefined
+    const currentExists = selectable.some(summary => summary.sessionId === this._state.sessionId)
+    const selectedId = preferredExists
+      ?? (currentExists ? this._state.sessionId : undefined)
+      ?? [...selectable].sort((left, right) => right.updatedAt - left.updatedAt).find(summary => !summary.blank)?.sessionId
+      ?? selectable[0]?.sessionId
 
-    this.publish({
-      sessions: visible.map(summary => ({ id: summary.sessionId, title: titleOf(summary) })),
-    })
+    if (selectedId !== undefined && this.unreadSessionIds.delete(selectedId)) this.persistUnreadSessions()
+    this.publish({ sessions: sessionItems(this.summaries, this.archivedSessionIds, selectedId, this.unreadSessionIds) })
     if (selectedId === undefined) {
       const created = await client.createSession(this.cwd)
       await this.loadSessions(created.sessionId)
       return
     }
     await this.loadSession(selectedId)
+  }
+
+  private async refreshArchivedSessions(client: DshClient): Promise<void> {
+    try {
+      const result = await client.listWorkspaces()
+      this.archivedSessionIds = new Set(Array.isArray(result.archivedSessionIds) ? result.archivedSessionIds : [])
+    } catch (error) {
+      this.output.appendLine(`[sessions] Archive state is unavailable in this DSH version: ${error instanceof Error ? error.message : String(error)}`)
+      this.archivedSessionIds.clear()
+    }
+  }
+
+  private publishSessionItems(): void {
+    this.publish({
+      sessions: sessionItems(this.summaries, this.archivedSessionIds, this._state.sessionId, this.unreadSessionIds),
+    })
+  }
+
+  private markRead(sessionId: string): void {
+    if (!this.unreadSessionIds.delete(sessionId)) return
+    this.persistUnreadSessions()
+    this.publishSessionItems()
+  }
+
+  private markUnread(sessionId: string): void {
+    if (this.unreadSessionIds.has(sessionId)) return
+    this.unreadSessionIds.add(sessionId)
+    this.persistUnreadSessions()
+  }
+
+  private persistUnreadSessions(): void {
+    void this.workspaceState.update(DshChatController.unreadStorageKey, [...this.unreadSessionIds])
+      .then(undefined, error => {
+        this.output.appendLine(`[sessions] Could not persist unread state: ${error instanceof Error ? error.message : String(error)}`)
+      })
   }
 
   private async loadSession(sessionId: string): Promise<void> {
@@ -722,7 +781,11 @@ class DshChatController implements vscode.Disposable {
         const dshEvent = event as DshEvent
         if (dshEvent.type === 'user/message') {
           const summary = this.summaries.find(item => item.sessionId === sessionId)
-          if (summary !== undefined) summary.blank = false
+          if (summary !== undefined) {
+            summary.blank = false
+            summary.updatedAt = Date.now()
+            this.publishSessionItems()
+          }
           this.publish({ agentPreset: lockAgentPresetState(this._state.agentPreset) })
         }
         if (dshEvent.type === 'agent-preset/selected') {
@@ -854,9 +917,8 @@ class DshChatController implements vscode.Disposable {
         summary.projections = { values: { ...summary.projections?.values, [payload.key]: payload.value } }
       }
       if (typeof payload.value === 'string' && payload.key === 'title') {
-        this.publish({
-          sessions: this._state.sessions.map(item => item.id === sessionId ? { ...item, title: payload.value as string } : item),
-        })
+        if (summary !== undefined) summary.updatedAt = Date.now()
+        this.publishSessionItems()
       }
       if (payload.key === 'imageLimits' && sessionId === this._state.sessionId) {
         this.publish({ imageLimits: imageLimitsOf(payload.value) })
@@ -880,8 +942,22 @@ class DshChatController implements vscode.Disposable {
     if (frame.channel === 'host' && type === 'host/session-status') {
       const running = payload.running === true
       const summary = this.summaries.find(item => item.sessionId === sessionId)
+      const wasRunning = summary?.running === true
       if (summary !== undefined) summary.running = running
+      if (wasRunning && !running && sessionId !== this._state.sessionId) this.markUnread(sessionId)
       if (sessionId === this._state.sessionId) this.publish({ running })
+      this.publishSessionItems()
+      return
+    }
+
+    if (frame.channel === 'host' && type === 'host/archived-sessions-changed') {
+      const archived = Array.isArray(payload.archivedSessionIds)
+        ? payload.archivedSessionIds.filter((value): value is string => typeof value === 'string')
+        : []
+      this.archivedSessionIds = new Set(archived)
+      for (const id of archived) this.unreadSessionIds.delete(id)
+      this.persistUnreadSessions()
+      void this.loadSessions().catch(error => { this.report(error) })
       return
     }
 
@@ -1248,6 +1324,43 @@ class DshSurface implements vscode.Disposable {
         case 'select-session':
           if (typeof value.sessionId === 'string') await this.controller.selectSession(value.sessionId)
           return
+        case 'rename-session':
+          if (typeof value.sessionId === 'string') {
+            const session = this.controller.state.sessions.find(item => item.id === value.sessionId)
+            if (session === undefined || session.blank) return
+            const title = await vscode.window.showInputBox({
+              title: 'Rename conversation',
+              value: session.title,
+              prompt: 'Choose a title for this DeepSeek conversation',
+              validateInput: input => input.trim() === '' ? 'Enter a conversation title.' : undefined,
+            })
+            if (title === undefined) return
+            try {
+              await this.controller.renameSession(session.id, title)
+            } catch (error) {
+              const detail = error instanceof Error ? error.message : String(error)
+              await vscode.window.showErrorMessage(`Could not rename the conversation. ${detail} Update DSH if this method is unavailable.`)
+            }
+          }
+          return
+        case 'archive-session':
+          if (typeof value.sessionId === 'string') {
+            const session = this.controller.state.sessions.find(item => item.id === value.sessionId)
+            if (session === undefined || session.blank) return
+            const confirmed = await vscode.window.showWarningMessage(
+              `Archive “${session.title}”?`,
+              { modal: true, detail: 'This removes the conversation from this sidebar. Its DSH session data is not deleted.' },
+              'Archive',
+            )
+            if (confirmed !== 'Archive') return
+            try {
+              await this.controller.archiveSession(session.id)
+            } catch (error) {
+              const detail = error instanceof Error ? error.message : String(error)
+              await vscode.window.showErrorMessage(`Could not archive the conversation. ${detail} Update DSH if this method is unavailable.`)
+            }
+          }
+          return
         case 'load-history': await this.controller.loadOlderHistory(); return
         case 'load-tool-output':
           if (typeof value.messageId === 'string' && typeof value.requestId === 'number') {
@@ -1591,7 +1704,7 @@ export function activate(context: vscode.ExtensionContext): void {
   }
   const cwd = workspace?.uri.fsPath ?? ''
   const diffReviews = new DiffReviewManager()
-  const controller = new DshChatController(runtime, output, new DirtyFileGuard(), diffReviews, cwd)
+  const controller = new DshChatController(runtime, output, new DirtyFileGuard(), diffReviews, context.workspaceState, cwd)
   const pluginManager = new DshPluginManager(context, controller, output)
   const editorContext = new EditorContextBridge(() => controller.cwd)
   const provider = new DshViewProvider(controller, output, editorContext, context.extensionUri)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1109,9 +1109,11 @@ class DshChatController implements vscode.Disposable {
   }
 }
 
+type DraftImage = PromptImage & { id: string }
+
 class DshSurface implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[]
-  private readonly draftImages: Array<PromptImage & { id: string }> = []
+  private readonly draftImagesBySession = new Map<string, DraftImage[]>()
   private ready = false
   private pendingFocus = false
   private pendingPrompt: string | undefined
@@ -1209,6 +1211,8 @@ class DshSurface implements vscode.Disposable {
   }
 
   private async chooseImages(): Promise<void> {
+    const sessionId = this.controller.state.sessionId
+    if (sessionId === '') return
     const selected = await vscode.window.showOpenDialog({
       title: 'Attach images to the DeepSeek prompt',
       canSelectFiles: true,
@@ -1218,7 +1222,7 @@ class DshSurface implements vscode.Disposable {
     })
     if (selected === undefined) return
 
-    const incoming: Array<PromptImage & { id: string }> = []
+    const incoming: DraftImage[] = []
     for (const uri of selected) {
       const mediaType = imageMediaType(uri.fsPath)
       if (mediaType === undefined) continue
@@ -1233,9 +1237,10 @@ class DshSurface implements vscode.Disposable {
     }
     if (incoming.length === 0) return
 
+    const draftImages = this.draftImagesFor(sessionId)
     // Answer with the runtime's own bounds before a rejected prompt spends the upload.
     const rejection = rejectImageAttachments(
-      this.draftImages.map(candidateOf),
+      draftImages.map(candidateOf),
       incoming.map(candidateOf),
       this.controller.state.imageLimits,
     )
@@ -1244,8 +1249,8 @@ class DshSurface implements vscode.Disposable {
       return
     }
 
-    this.draftImages.push(...incoming)
-    await this.publishDraftImages()
+    draftImages.push(...incoming)
+    await this.publishDraftImages(sessionId)
   }
 
   private async chooseWorkspace(): Promise<void> {
@@ -1286,10 +1291,19 @@ class DshSurface implements vscode.Disposable {
     }
   }
 
-  private async publishDraftImages(): Promise<void> {
+  private draftImagesFor(sessionId: string): DraftImage[] {
+    const existing = this.draftImagesBySession.get(sessionId)
+    if (existing !== undefined) return existing
+    const created: DraftImage[] = []
+    this.draftImagesBySession.set(sessionId, created)
+    return created
+  }
+
+  private async publishDraftImages(sessionId: string): Promise<void> {
     await this.webview.postMessage({
       type: 'draft-images',
-      images: this.draftImages.map(image => ({ id: image.id, name: image.name, mediaType: image.mediaType })),
+      sessionId,
+      images: this.draftImagesFor(sessionId).map(image => ({ id: image.id, name: image.name, mediaType: image.mediaType })),
     })
   }
 
@@ -1384,6 +1398,9 @@ class DshSurface implements vscode.Disposable {
           return
         case 'send':
           if (typeof value.text === 'string') {
+            const sessionId = this.controller.state.sessionId
+            if (sessionId === '') return
+            const draftImages = this.draftImagesFor(sessionId)
             if (value.text.trim() === '/permission danger-full-access') {
               const confirmed = await vscode.window.showWarningMessage(
                 'Enable Full access?',
@@ -1403,7 +1420,7 @@ class DshSurface implements vscode.Disposable {
             // where the whole draft can be measured against what the runtime states.
             const rejection = rejectImageAttachments(
               [],
-              this.draftImages.map(candidateOf),
+              draftImages.map(candidateOf),
               this.controller.state.imageLimits,
             )
             if (rejection !== undefined) {
@@ -1411,10 +1428,11 @@ class DshSurface implements vscode.Disposable {
               this.setPrompt(value.text)
               return
             }
-            await this.controller.send(value.text, this.draftImages, ideContext, mode)
-            this.draftImages.length = 0
+            if (this.controller.state.sessionId !== sessionId) return
+            await this.controller.send(value.text, draftImages, ideContext, mode)
+            this.draftImagesBySession.delete(sessionId)
             if (carriesIdeContext) this.editorContext.clearPinned()
-            await this.publishDraftImages()
+            await this.publishDraftImages(sessionId)
           }
           return
         case 'select-permission':
@@ -1463,9 +1481,12 @@ class DshSurface implements vscode.Disposable {
           return
         case 'remove-attachment':
           if (typeof value.id === 'string') {
-            const index = this.draftImages.findIndex(image => image.id === value.id)
-            if (index >= 0) this.draftImages.splice(index, 1)
-            await this.publishDraftImages()
+            const sessionId = this.controller.state.sessionId
+            if (sessionId === '') return
+            const draftImages = this.draftImagesFor(sessionId)
+            const index = draftImages.findIndex(image => image.id === value.id)
+            if (index >= 0) draftImages.splice(index, 1)
+            await this.publishDraftImages(sessionId)
           }
           return
         case 'cancel': await this.controller.cancel(); return
@@ -1562,7 +1583,7 @@ function base64Bytes(data: string): number {
 }
 
 /** Measure a draft attachment against the runtime's published upload bounds. */
-function candidateOf(image: PromptImage & { id: string }): ImageCandidate {
+function candidateOf(image: DraftImage): ImageCandidate {
   return {
     mediaType: image.mediaType,
     bytes: base64Bytes(image.data),

--- a/src/session-center.ts
+++ b/src/session-center.ts
@@ -1,0 +1,41 @@
+import type { SessionSummary } from './dsh-client.js'
+
+export interface SessionItem {
+  id: string
+  title: string
+  updatedAt: number
+  running: boolean
+  blank: boolean
+  unread: boolean
+}
+
+export function sessionTitle(summary: SessionSummary): string {
+  const value = summary.projections?.values?.title
+  return typeof value === 'string' && value.trim() !== '' ? value.trim() : 'New conversation'
+}
+
+export function sessionItems(
+  summaries: readonly SessionSummary[],
+  archivedSessionIds: ReadonlySet<string>,
+  selectedId: string | undefined,
+  unreadSessionIds: ReadonlySet<string>,
+): SessionItem[] {
+  return summaries
+    .filter(summary => !archivedSessionIds.has(summary.sessionId))
+    .filter(summary => !summary.blank || summary.sessionId === selectedId)
+    .map(summary => ({
+      id: summary.sessionId,
+      title: sessionTitle(summary),
+      updatedAt: summary.updatedAt,
+      running: summary.running,
+      blank: summary.blank,
+      unread: unreadSessionIds.has(summary.sessionId),
+    }))
+    .sort((left, right) => right.updatedAt - left.updatedAt)
+}
+
+export function filterSessionItems(items: readonly SessionItem[], query: string): SessionItem[] {
+  const normalized = query.trim().toLocaleLowerCase()
+  if (normalized === '') return [...items]
+  return items.filter(item => item.title.toLocaleLowerCase().includes(normalized))
+}

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -329,6 +329,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     };
     let state;
     let draftImages = [];
+    const draftImagesBySession = new Map();
     let ideContext = { pinned: [] };
     let commandIndex = 0;
     let mentionIndex = 0;
@@ -1440,6 +1441,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         if (renderedSessionId) sessionDrafts.set(renderedSessionId, elements.prompt.value);
         renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
         elements.prompt.value = sessionDrafts.get(current.sessionId) || ''; resizePrompt();
+        draftImages = draftImagesBySession.get(current.sessionId) || []; renderAttachments();
         followConversationTail = true;
         renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear();
         for (const request of loadingToolRequests.values()) clearTimeout(request.timer);
@@ -1644,7 +1646,10 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
           }
         }
       }
-      if (event.data.type === 'draft-images') { draftImages = event.data.images || []; renderAttachments(); }
+      if (event.data.type === 'draft-images' && typeof event.data.sessionId === 'string') {
+        const images = event.data.images || []; draftImagesBySession.set(event.data.sessionId, images);
+        if (state && event.data.sessionId === state.sessionId) { draftImages = images; renderAttachments(); }
+      }
       if (event.data.type === 'ide-context') { ideContext = event.data.state || { pinned: [] }; renderIdeContext(); }
       if (event.data.type === 'mention-suggestions' && event.data.requestId === mentionRequestId) {
         const mention = currentMentionQuery();

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -29,7 +29,30 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     button { cursor: pointer; }
     #app { width: 100%; height: 100%; min-width: 0; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; overflow: hidden; }
     .toolbar { min-width: 0; min-height: 38px; padding: 4px 8px 4px 12px; display: flex; align-items: center; gap: 6px; border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border, transparent); }
-    .session-select { min-width: 0; flex: 1; border: 0; outline: 0; background: transparent; font-weight: 600; text-overflow: ellipsis; }
+    .session-control { min-width: 0; flex: 1; position: relative; }
+    .session-trigger { width: 100%; min-width: 0; height: 28px; padding: 0 6px; display: flex; align-items: center; gap: 5px; border: 0; border-radius: 6px; background: transparent; font-weight: 600; text-align: left; }
+    .session-trigger:hover, .session-trigger[aria-expanded="true"] { background: var(--vscode-toolbar-hoverBackground); }
+    .session-trigger-title { min-width: 0; flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+    .session-trigger svg { width: 13px; height: 13px; flex: 0 0 auto; color: var(--vscode-descriptionForeground); }
+    .session-menu { position: absolute; z-index: 30; top: calc(100% + 5px); left: -40px; width: calc(100vw - 16px); max-width: 360px; max-height: min(430px, 72vh); padding: 6px; display: grid; grid-template-rows: auto minmax(0, 1fr); border: 1px solid var(--vscode-widget-border); border-radius: 9px; background: var(--vscode-menu-background, var(--vscode-editor-background)); box-shadow: 0 7px 24px var(--vscode-widget-shadow); }
+    .session-search { width: 100%; height: 29px; padding: 0 8px; border: 1px solid var(--vscode-input-border, transparent); border-radius: 5px; outline: 0; color: var(--vscode-input-foreground); background: var(--vscode-input-background); }
+    .session-list { min-height: 0; margin-top: 5px; overflow: auto; }
+    .session-empty { padding: 18px 8px; color: var(--vscode-descriptionForeground); text-align: center; font-size: 11px; }
+    .session-row { min-width: 0; display: grid; grid-template-columns: minmax(0, 1fr) 26px; align-items: center; border-radius: 6px; }
+    .session-row:hover, .session-row.active { background: var(--vscode-list-hoverBackground); }
+    .session-row.active { color: var(--vscode-list-activeSelectionForeground, var(--vscode-foreground)); background: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground)); }
+    .session-main { min-width: 0; min-height: 44px; padding: 5px 6px; display: grid; grid-template-columns: 9px minmax(0, 1fr); grid-template-rows: auto auto; column-gap: 7px; border: 0; background: transparent; text-align: left; }
+    .session-indicator { grid-row: 1 / 3; align-self: center; width: 6px; height: 6px; border-radius: 50%; background: transparent; }
+    .session-indicator.running { background: var(--vscode-charts-blue, #4d6bfe); box-shadow: 0 0 0 2px color-mix(in srgb, var(--vscode-charts-blue, #4d6bfe) 20%, transparent); }
+    .session-indicator.unread { background: var(--vscode-notificationsInfoIcon-foreground, #4d6bfe); }
+    .session-name { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; font-size: 12px; font-weight: 600; }
+    .session-meta { min-width: 0; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; color: var(--vscode-descriptionForeground); font-size: 10px; }
+    .session-more { width: 24px; height: 24px; min-width: 24px; padding: 0; display: grid; place-items: center; border: 0; border-radius: 5px; color: var(--vscode-descriptionForeground); background: transparent; font-size: 17px; line-height: 1; }
+    .session-more:hover { color: var(--vscode-foreground); background: var(--vscode-toolbar-hoverBackground); }
+    .session-actions { grid-column: 1 / -1; margin: 0 5px 5px 22px; padding: 3px; display: flex; border: 1px solid var(--vscode-widget-border); border-radius: 6px; background: var(--vscode-editor-background); }
+    .session-action { min-height: 25px; padding: 2px 7px; border: 0; border-radius: 4px; color: var(--vscode-foreground); background: transparent; font-size: 11px; }
+    .session-action:hover { background: var(--vscode-toolbar-hoverBackground); }
+    .session-action.danger { color: var(--vscode-errorForeground); }
     .icon-button { width: 28px; height: 28px; min-width: 28px; padding: 0; display: grid; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--vscode-icon-foreground); }
     .icon-button:hover { background: var(--vscode-toolbar-hoverBackground); }
     .github-star:hover { color: var(--vscode-charts-yellow, #e3b341); }
@@ -239,7 +262,13 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
   <div id="app">
     <header class="toolbar">
       <button id="githubStar" class="icon-button github-star" title="Star dsh-vscode on GitHub" aria-label="Star dsh-vscode on GitHub"><svg viewBox="0 0 24 24"><path d="m12 3 2.8 5.7 6.3.9-4.6 4.4 1.1 6.2-5.6-3-5.6 3 1.1-6.2-4.6-4.4 6.3-.9z"/></svg></button>
-      <select id="sessions" class="session-select" aria-label="Project conversations"></select>
+      <div id="sessionControl" class="session-control">
+        <button id="sessionTrigger" class="session-trigger" aria-label="Project conversations" aria-haspopup="dialog" aria-expanded="false"><span id="sessionTriggerTitle" class="session-trigger-title">New conversation</span><svg viewBox="0 0 24 24"><path d="m7 9.5 5 5 5-5"/></svg></button>
+        <div id="sessionMenu" class="session-menu hidden" role="dialog" aria-label="Project conversations">
+          <input id="sessionSearch" class="session-search" type="search" placeholder="Search conversations" aria-label="Search conversations">
+          <div id="sessionList" class="session-list" role="listbox"></div>
+        </div>
+      </div>
       <div id="jobsControl" class="jobs-control hidden">
         <button id="jobsTrigger" class="icon-button jobs-trigger" title="Background jobs" aria-label="Background jobs" aria-haspopup="menu" aria-expanded="false"><span class="jobs-dot"></span><span id="jobsCount">0</span></button>
         <div id="jobsMenu" class="jobs-menu hidden" role="menu" aria-label="Background jobs"></div>
@@ -288,7 +317,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     const elements = {
       conversation: document.getElementById('conversation'), scroll: document.getElementById('scroll'),
       conversationStatus: document.getElementById('conversationStatus'), conversationHistory: document.getElementById('conversationHistory'), messages: document.getElementById('messages'), conversationTail: document.getElementById('conversationTail'),
-      githubStar: document.getElementById('githubStar'), sessions: document.getElementById('sessions'), newSession: document.getElementById('newSession'), jobsControl: document.getElementById('jobsControl'), jobsTrigger: document.getElementById('jobsTrigger'), jobsCount: document.getElementById('jobsCount'), jobsMenu: document.getElementById('jobsMenu'),
+      githubStar: document.getElementById('githubStar'), sessionControl: document.getElementById('sessionControl'), sessionTrigger: document.getElementById('sessionTrigger'), sessionTriggerTitle: document.getElementById('sessionTriggerTitle'), sessionMenu: document.getElementById('sessionMenu'), sessionSearch: document.getElementById('sessionSearch'), sessionList: document.getElementById('sessionList'), newSession: document.getElementById('newSession'), jobsControl: document.getElementById('jobsControl'), jobsTrigger: document.getElementById('jobsTrigger'), jobsCount: document.getElementById('jobsCount'), jobsMenu: document.getElementById('jobsMenu'),
       prompt: document.getElementById('prompt'), project: document.getElementById('project'), workspace: document.getElementById('workspace'),
       models: document.getElementById('models'), efforts: document.getElementById('efforts'),
       policyTrigger: document.getElementById('policyTrigger'), policyMenu: document.getElementById('policyMenu'),
@@ -310,6 +339,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let policyMenuOpen = false;
     let usageOpen = false;
     let jobsOpen = false;
+    let sessionMenuOpen = false;
+    let sessionActionId;
     let jobsTimer;
     let historyAnchor;
     let renderFrame;
@@ -321,6 +352,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let renderedHistoryKey = '';
     let renderedTail = {};
     let renderedChrome = {};
+    const sessionDrafts = new Map();
     const renderedMessages = new Map();
     const expandedToolIds = new Set();
     const loadingToolRequests = new Map();
@@ -364,6 +396,66 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (className) value.className = className;
       if (text !== undefined) value.textContent = text;
       return value;
+    }
+
+    function relativeSessionTime(value) {
+      const elapsed = Math.max(0, Date.now() - Number(value || 0));
+      const minutes = Math.floor(elapsed / 60000);
+      if (minutes < 1) return 'Just now';
+      if (minutes < 60) return minutes + 'm ago';
+      const hours = Math.floor(minutes / 60);
+      if (hours < 24) return hours + 'h ago';
+      const days = Math.floor(hours / 24);
+      return days === 1 ? 'Yesterday' : days + 'd ago';
+    }
+    function closeSessionMenu(focusTrigger) {
+      sessionMenuOpen = false; sessionActionId = undefined;
+      elements.sessionSearch.value = '';
+      elements.sessionMenu.classList.add('hidden'); elements.sessionTrigger.setAttribute('aria-expanded', 'false');
+      if (focusTrigger) elements.sessionTrigger.focus();
+    }
+    function renderSessionCenter(current) {
+      const sessions = array(current.sessions);
+      const selected = sessions.find(session => session.id === current.sessionId);
+      elements.sessionTriggerTitle.textContent = selected ? selected.title : 'New conversation';
+      elements.sessionTrigger.title = selected ? selected.title : 'Project conversations';
+      elements.sessionList.replaceChildren();
+      const query = elements.sessionSearch.value.trim().toLocaleLowerCase();
+      const visible = sessions.filter(session => !query || string(session.title).toLocaleLowerCase().includes(query));
+      if (!visible.length) {
+        elements.sessionList.append(node('div', 'session-empty', query ? 'No matching conversations' : 'No conversations yet'));
+        return;
+      }
+      for (const session of visible) {
+        const row = node('div', 'session-row' + (session.id === current.sessionId ? ' active' : ''));
+        row.setAttribute('role', 'option'); row.setAttribute('aria-selected', String(session.id === current.sessionId));
+        const main = node('button', 'session-main'); main.type = 'button';
+        const indicator = node('span', 'session-indicator' + (session.running ? ' running' : session.unread ? ' unread' : ''));
+        indicator.title = session.running ? 'Running' : session.unread ? 'New activity' : '';
+        const title = node('span', 'session-name', string(session.title, 'New conversation'));
+        const meta = node('span', 'session-meta', session.running ? 'Running' : session.unread ? 'New activity' : relativeSessionTime(session.updatedAt));
+        main.append(indicator, title, meta);
+        main.addEventListener('click', () => {
+          if (state && state.sessionId) sessionDrafts.set(state.sessionId, elements.prompt.value);
+          closeSessionMenu(false);
+          if (!state || session.id !== state.sessionId) vscode.postMessage({ type: 'select-session', sessionId: session.id });
+        });
+        row.append(main);
+        if (!session.blank) {
+          const more = node('button', 'session-more', '…'); more.type = 'button'; more.title = 'Conversation actions'; more.setAttribute('aria-label', 'Actions for ' + string(session.title));
+          more.addEventListener('click', event => { event.stopPropagation(); sessionActionId = sessionActionId === session.id ? undefined : session.id; renderSessionCenter(current); });
+          row.append(more);
+          if (sessionActionId === session.id) {
+            const actions = node('div', 'session-actions');
+            const rename = node('button', 'session-action', 'Rename'); rename.type = 'button';
+            rename.addEventListener('click', () => { closeSessionMenu(false); vscode.postMessage({ type: 'rename-session', sessionId: session.id }); });
+            const archive = node('button', 'session-action danger', 'Archive'); archive.type = 'button';
+            archive.addEventListener('click', () => { closeSessionMenu(false); vscode.postMessage({ type: 'archive-session', sessionId: session.id }); });
+            actions.append(rename, archive); row.append(actions);
+          }
+        }
+        elements.sessionList.append(row);
+      }
     }
 
     function record(value) { return value && typeof value === 'object' && !Array.isArray(value) ? value : undefined; }
@@ -1345,7 +1437,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     }
     function renderConversation(current) {
       if (renderedSessionId !== current.sessionId) {
+        if (renderedSessionId) sessionDrafts.set(renderedSessionId, elements.prompt.value);
         renderedSessionId = current.sessionId; renderedMessages.clear(); elements.messages.replaceChildren();
+        elements.prompt.value = sessionDrafts.get(current.sessionId) || ''; resizePrompt();
         followConversationTail = true;
         renderedHistoryKey = ''; renderedTail = {}; expandedToolIds.clear();
         for (const request of loadingToolRequests.values()) clearTimeout(request.timer);
@@ -1394,11 +1488,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (renderedChrome.workspaceName !== current.workspaceName || renderedChrome.cwd !== current.cwd) {
         elements.workspace.textContent = current.workspaceName || 'Workspace'; elements.project.title = current.cwd ? 'DeepSeek project: ' + current.cwd : 'Choose DeepSeek project';
       }
-      if (renderedChrome.sessions !== current.sessions) {
-        elements.sessions.replaceChildren();
-        for (const session of current.sessions || []) { const option = new Option(session.title, session.id, false, session.id === current.sessionId); elements.sessions.append(option); }
-        if (!elements.sessions.childElementCount) elements.sessions.append(new Option('New conversation', ''));
-      } else if (elements.sessions.value !== current.sessionId) elements.sessions.value = current.sessionId;
+      if (renderedChrome.sessions !== current.sessions || renderedChrome.sessionId !== current.sessionId) renderSessionCenter(current);
       if (renderedChrome.models !== current.models) {
         elements.models.replaceChildren();
         for (const model of current.models || []) { const option = new Option(model.label, JSON.stringify({ provider: model.provider, model: model.model }), false, model.selected === true); elements.models.append(option); }
@@ -1411,12 +1501,12 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (renderedChrome.jobs !== current.jobs) renderJobs();
       renderConversation(current);
       const enabled = current.phase === 'ready' && current.routable !== false && Boolean(current.sessionId);
-      elements.prompt.disabled = !enabled; elements.attach.disabled = !enabled; elements.project.disabled = current.running === true; elements.newSession.disabled = current.phase !== 'ready'; elements.sessions.disabled = current.phase !== 'ready';
+      elements.prompt.disabled = !enabled; elements.attach.disabled = !enabled; elements.project.disabled = current.running === true; elements.newSession.disabled = current.phase !== 'ready'; elements.sessionTrigger.disabled = current.phase !== 'ready';
       elements.models.disabled = !enabled || !(current.models || []).length; elements.efforts.disabled = !enabled || !elements.efforts.options.length || elements.efforts.value === '';
       elements.cancel.classList.toggle('hidden', current.running !== true); elements.send.title = current.running ? 'Queue message (Enter) · Steer now (Cmd/Ctrl+Enter)' : 'Send (Enter)'; updateSend(); renderQueue();
       if (renderedChrome.commands !== current.commands || renderedChrome.skills !== current.skills || renderedChrome.permissions !== current.permissions) renderCommandMenu();
       renderedChrome = {
-        workspaceName: current.workspaceName, cwd: current.cwd, sessions: current.sessions, models: current.models,
+        workspaceName: current.workspaceName, cwd: current.cwd, sessions: current.sessions, sessionId: current.sessionId, models: current.models,
         agentPreset: current.agentPreset, permissions: current.permissions, plan: current.plan, running: current.running,
         phase: current.phase, usage: current.usage, jobs: current.jobs, commands: current.commands, skills: current.skills,
       };
@@ -1465,9 +1555,9 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     function selectionFor(model, reasoningEffort) { return { provider: model.provider, model: model.model, ...(reasoningEffort ? { reasoningEffort } : {}) }; }
     function send(mode) {
       const text = elements.prompt.value.trim(); if ((!text && !draftImages.length) || !state || state.phase !== 'ready') return;
-      vscode.postMessage({ type: 'send', text, mode: mode || 'queue' }); elements.prompt.value = ''; commandIndex = 0; resetPrompt();
+      vscode.postMessage({ type: 'send', text, mode: mode || 'queue' }); elements.prompt.value = ''; sessionDrafts.set(state.sessionId, ''); commandIndex = 0; resetPrompt();
     }
-    elements.prompt.addEventListener('input', () => { policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); commandIndex = 0; mentionIndex = 0; elements.prompt.placeholder = 'Ask DeepSeek about this project'; resizePrompt(); renderCommandMenu(); requestMentions(); });
+    elements.prompt.addEventListener('input', () => { if (state && state.sessionId) sessionDrafts.set(state.sessionId, elements.prompt.value); policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); commandIndex = 0; mentionIndex = 0; elements.prompt.placeholder = 'Ask DeepSeek about this project'; resizePrompt(); renderCommandMenu(); requestMentions(); });
     elements.prompt.addEventListener('click', () => { policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); requestMentions(); });
     elements.prompt.addEventListener('keydown', event => {
       if (policyMenuOpen && event.key === 'Escape') { event.preventDefault(); policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); return; }
@@ -1497,7 +1587,15 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     });
     elements.project.addEventListener('click', () => vscode.postMessage({ type: 'choose-workspace' }));
     elements.githubStar.addEventListener('click', () => vscode.postMessage({ type: 'open-link', href: 'https://github.com/Lixxx1/dsh-vscode' }));
-    elements.newSession.addEventListener('click', () => vscode.postMessage({ type: 'new-session' })); elements.sessions.addEventListener('change', () => vscode.postMessage({ type: 'select-session', sessionId: elements.sessions.value }));
+    elements.sessionTrigger.addEventListener('click', event => {
+      event.stopPropagation();
+      if (sessionMenuOpen) { closeSessionMenu(false); return; }
+      sessionMenuOpen = true; sessionActionId = undefined; elements.sessionMenu.classList.remove('hidden'); elements.sessionTrigger.setAttribute('aria-expanded', 'true');
+      renderSessionCenter(state || { sessions: [] }); requestAnimationFrame(() => elements.sessionSearch.focus());
+    });
+    elements.sessionSearch.addEventListener('input', () => { sessionActionId = undefined; if (state) renderSessionCenter(state); });
+    elements.sessionMenu.addEventListener('click', event => event.stopPropagation());
+    elements.newSession.addEventListener('click', () => { if (state && state.sessionId) sessionDrafts.set(state.sessionId, elements.prompt.value); closeSessionMenu(false); vscode.postMessage({ type: 'new-session' }); });
     elements.models.addEventListener('change', () => {
       if (!elements.models.value) return; const selected = JSON.parse(elements.models.value); const model = (state.models || []).find(item => item.provider === selected.provider && item.model === selected.model); if (!model) return;
       renderEfforts(model); const effort = model.defaultReasoningEffort || (model.reasoningEfforts && model.reasoningEfforts[0] && model.reasoningEfforts[0].id); if (effort) elements.efforts.value = effort;
@@ -1514,9 +1612,12 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (jobsOpen && !elements.jobsMenu.contains(event.target) && !elements.jobsTrigger.contains(event.target)) {
         jobsOpen = false; elements.jobsMenu.classList.add('hidden'); elements.jobsTrigger.setAttribute('aria-expanded', 'false'); renderJobs();
       }
+      if (sessionMenuOpen && !elements.sessionControl.contains(event.target)) closeSessionMenu(false);
     });
     document.addEventListener('keydown', event => {
-      if (event.key === 'Escape' && usageOpen) {
+      if (event.key === 'Escape' && sessionMenuOpen) {
+        event.preventDefault(); closeSessionMenu(true);
+      } else if (event.key === 'Escape' && usageOpen) {
         usageOpen = false; elements.usagePanel.classList.add('hidden'); elements.usageTrigger.setAttribute('aria-expanded', 'false'); elements.usageTrigger.focus();
       }
     });
@@ -1551,7 +1652,7 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       }
       if (event.data.type === 'focus-prompt') elements.prompt.focus();
       if (event.data.type === 'set-prompt' && typeof event.data.text === 'string') {
-        elements.prompt.value = event.data.text; resizePrompt(); requestMentions(); renderCommandMenu(); elements.prompt.focus();
+        elements.prompt.value = event.data.text; if (state && state.sessionId) sessionDrafts.set(state.sessionId, event.data.text); resizePrompt(); requestMentions(); renderCommandMenu(); elements.prompt.focus();
         const cursor = elements.prompt.value.length; elements.prompt.setSelectionRange(cursor, cursor);
       }
     });

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -354,6 +354,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     let renderedTail = {};
     let renderedChrome = {};
     const sessionDrafts = new Map();
+    const pendingDraftSends = new Map();
+    let draftSendRequestId = 0;
     const renderedMessages = new Map();
     const expandedToolIds = new Set();
     const loadingToolRequests = new Map();
@@ -1552,12 +1554,17 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
         : state.messages;
       scheduleRender({ ...state, ...patch, messages });
     }
-    function updateSend() { elements.send.disabled = !state || state.phase !== 'ready' || (elements.prompt.value.trim() === '' && draftImages.length === 0); }
+    function updateSend() {
+      const pending = state && [...pendingDraftSends.values()].some(draft => draft.sessionId === state.sessionId);
+      elements.send.disabled = !state || state.phase !== 'ready' || pending || (elements.prompt.value.trim() === '' && draftImages.length === 0);
+    }
     function resizePrompt() { elements.prompt.style.height = 'auto'; elements.prompt.style.height = Math.min(elements.prompt.scrollHeight, 220) + 'px'; updateSend(); }
     function selectionFor(model, reasoningEffort) { return { provider: model.provider, model: model.model, ...(reasoningEffort ? { reasoningEffort } : {}) }; }
     function send(mode) {
       const text = elements.prompt.value.trim(); if ((!text && !draftImages.length) || !state || state.phase !== 'ready') return;
-      vscode.postMessage({ type: 'send', text, mode: mode || 'queue' }); elements.prompt.value = ''; sessionDrafts.set(state.sessionId, ''); commandIndex = 0; resetPrompt();
+      const requestId = ++draftSendRequestId; const sessionId = state.sessionId;
+      pendingDraftSends.set(requestId, { sessionId, text });
+      vscode.postMessage({ type: 'send', sessionId, requestId, text, mode: mode || 'queue' }); elements.prompt.value = ''; sessionDrafts.set(sessionId, ''); commandIndex = 0; resetPrompt();
     }
     elements.prompt.addEventListener('input', () => { if (state && state.sessionId) sessionDrafts.set(state.sessionId, elements.prompt.value); policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); commandIndex = 0; mentionIndex = 0; elements.prompt.placeholder = 'Ask DeepSeek about this project'; resizePrompt(); renderCommandMenu(); requestMentions(); });
     elements.prompt.addEventListener('click', () => { policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); requestMentions(); });
@@ -1649,6 +1656,20 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (event.data.type === 'draft-images' && typeof event.data.sessionId === 'string') {
         const images = event.data.images || []; draftImagesBySession.set(event.data.sessionId, images);
         if (state && event.data.sessionId === state.sessionId) { draftImages = images; renderAttachments(); }
+      }
+      if ((event.data.type === 'draft-sent' || event.data.type === 'restore-draft') && typeof event.data.requestId === 'number') {
+        const pending = pendingDraftSends.get(event.data.requestId);
+        if (!pending || pending.sessionId !== event.data.sessionId) return;
+        pendingDraftSends.delete(event.data.requestId);
+        if (event.data.type === 'restore-draft') {
+          const existing = sessionDrafts.get(pending.sessionId) || '';
+          const restored = existing === '' || existing === pending.text ? pending.text : pending.text + '\\n' + existing;
+          sessionDrafts.set(pending.sessionId, restored);
+          if (state && state.sessionId === pending.sessionId) {
+            elements.prompt.value = restored; resizePrompt(); requestMentions(); renderCommandMenu();
+          }
+        }
+        updateSend();
       }
       if (event.data.type === 'ide-context') { ideContext = event.data.state || { pinned: [] }; renderIdeContext(); }
       if (event.data.type === 'mention-suggestions' && event.data.requestId === mentionRequestId) {

--- a/tests/dsh-client.spec.ts
+++ b/tests/dsh-client.spec.ts
@@ -48,6 +48,35 @@ describe('DshClient queue protocol', () => {
     ])
   })
 
+  it('uses the official session rename and workspace archive RPCs', async () => {
+    const requests: Array<{ method: string; payload: unknown }> = []
+    vi.stubGlobal('fetch', vi.fn(async (_url: URL, init?: RequestInit) => {
+      const request = JSON.parse(String(init?.body)) as { rpcId: string; method: string; payload: unknown }
+      requests.push({ method: request.method, payload: request.payload })
+      const value = request.method === 'workspace.list'
+        ? { archivedSessionIds: ['archived-1'] }
+        : request.method === 'workspace.archiveSession'
+          ? { archivedSessionIds: ['archived-1', 'session-1'] }
+          : { title: 'Renamed', seq: 12 }
+      return new Response(JSON.stringify({
+        type: 'server-response',
+        rpcId: request.rpcId,
+        result: { ok: true, value },
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    }))
+    const client = new DshClient(new URL('http://127.0.0.1:31415'))
+
+    await expect(client.listWorkspaces()).resolves.toEqual({ archivedSessionIds: ['archived-1'] })
+    await expect(client.renameSession('session-1', 'Renamed')).resolves.toMatchObject({ title: 'Renamed' })
+    await expect(client.archiveSession('session-1')).resolves.toEqual({ archivedSessionIds: ['archived-1', 'session-1'] })
+
+    expect(requests).toEqual([
+      { method: 'workspace.list', payload: {} },
+      { method: 'session.rename', payload: { sessionId: 'session-1', title: 'Renamed' } },
+      { method: 'workspace.archiveSession', payload: { sessionId: 'session-1' } },
+    ])
+  })
+
   it('reads the official runtime plugin inventory without inventing a management RPC', async () => {
     const requests: Array<{ method: string; payload: unknown }> = []
     vi.stubGlobal('fetch', vi.fn(async (_url: URL, init?: RequestInit) => {

--- a/tests/session-center.spec.ts
+++ b/tests/session-center.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionSummary } from '../src/dsh-client.js'
+import { filterSessionItems, sessionItems, sessionTitle } from '../src/session-center.js'
+
+function summary(overrides: Partial<SessionSummary> & Pick<SessionSummary, 'sessionId'>): SessionSummary {
+  return {
+    updatedAt: 0,
+    running: false,
+    blank: false,
+    ...overrides,
+  }
+}
+
+describe('session center state', () => {
+  it('uses the official title projection with a friendly blank fallback', () => {
+    expect(sessionTitle(summary({ sessionId: 'one', projections: { values: { title: '  Fix login  ' } } }))).toBe('Fix login')
+    expect(sessionTitle(summary({ sessionId: 'two', projections: { values: { title: '   ' } } }))).toBe('New conversation')
+  })
+
+  it('hides archived and unrelated blank sessions while preserving status metadata', () => {
+    const items = sessionItems([
+      summary({ sessionId: 'older', updatedAt: 10, running: true }),
+      summary({ sessionId: 'newer', updatedAt: 30, projections: { values: { title: 'Latest work' } } }),
+      summary({ sessionId: 'blank-selected', updatedAt: 20, blank: true }),
+      summary({ sessionId: 'blank-hidden', updatedAt: 40, blank: true }),
+      summary({ sessionId: 'archived', updatedAt: 50 }),
+    ], new Set(['archived']), 'blank-selected', new Set(['newer']))
+
+    expect(items).toEqual([
+      expect.objectContaining({ id: 'newer', title: 'Latest work', unread: true }),
+      expect.objectContaining({ id: 'blank-selected', blank: true }),
+      expect.objectContaining({ id: 'older', running: true }),
+    ])
+  })
+
+  it('searches titles case-insensitively without changing recency order', () => {
+    const items = sessionItems([
+      summary({ sessionId: 'one', updatedAt: 20, projections: { values: { title: 'Fix Windows paths' } } }),
+      summary({ sessionId: 'two', updatedAt: 10, projections: { values: { title: 'Review PATH handling' } } }),
+      summary({ sessionId: 'three', updatedAt: 30, projections: { values: { title: 'Write docs' } } }),
+    ], new Set(), undefined, new Set())
+
+    expect(filterSessionItems(items, 'path').map(item => item.id)).toEqual(['one', 'two'])
+  })
+})

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -32,6 +32,8 @@ describe('chat webview', () => {
     expect(html).toContain("type: 'archive-session'")
     expect(html).toContain('const sessionDrafts = new Map()')
     expect(html).toContain('const draftImagesBySession = new Map()')
+    expect(html).toContain('const pendingDraftSends = new Map()')
+    expect(html).toContain("event.data.type === 'restore-draft'")
     expect(html).not.toContain('<select id="sessions"')
   })
 

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -31,6 +31,7 @@ describe('chat webview', () => {
     expect(html).toContain("type: 'rename-session'")
     expect(html).toContain("type: 'archive-session'")
     expect(html).toContain('const sessionDrafts = new Map()')
+    expect(html).toContain('const draftImagesBySession = new Map()')
     expect(html).not.toContain('<select id="sessions"')
   })
 

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -22,6 +22,18 @@ describe('chat webview', () => {
     expect(html).toContain("href: 'https://github.com/Lixxx1/dsh-vscode'")
   })
 
+  it('uses a searchable session center with official rename and archive actions', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const html = chatHtml(webview, mark)
+
+    expect(html).toContain('placeholder="Search conversations"')
+    expect(html).toContain("type: 'rename-session'")
+    expect(html).toContain("type: 'archive-session'")
+    expect(html).toContain('const sessionDrafts = new Map()')
+    expect(html).not.toContain('<select id="sessions"')
+  })
+
   it('offers actionable setup states instead of a generic reconnect loop', () => {
     const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
     const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri


### PR DESCRIPTION
## Summary

- replace the native conversation select with a searchable session panel
- show the active conversation, running and unread states, and recent activity
- add official DSH rename and archive actions with archive-state synchronization
- keep text drafts separate when switching between conversations
- fall back cleanly when an older DSH runtime does not expose workspace archives

## Validation

- npm run check
- npm run package