### PR TITLE
feat: support pasting images from the clipboard

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1235,6 +1235,11 @@ class DshSurface implements vscode.Disposable {
         name: path.basename(uri.fsPath),
       })
     }
+
+    await this.addDraftImages(sessionId, incoming)
+  }
+
+  private async addDraftImages(sessionId: string, incoming: readonly DraftImage[]): Promise<void> {
     if (incoming.length === 0) return
 
     const draftImages = this.draftImagesFor(sessionId)
@@ -1251,6 +1256,16 @@ class DshSurface implements vscode.Disposable {
 
     draftImages.push(...incoming)
     await this.publishDraftImages(sessionId)
+  }
+
+  private async addEncodedImages(sessionId: string, values: unknown): Promise<void> {
+    if (sessionId !== this.controller.state.sessionId || !Array.isArray(values)) return
+    const incoming: DraftImage[] = []
+    for (const value of values) {
+      const image = draftImageFromWebview(value)
+      if (image !== undefined) incoming.push(image)
+    }
+    await this.addDraftImages(sessionId, incoming)
   }
 
   private async chooseWorkspace(): Promise<void> {
@@ -1501,6 +1516,12 @@ class DshSurface implements vscode.Disposable {
           if (typeof value.agentPreset === 'string') await this.controller.selectAgentPreset(value.agentPreset)
           return
         case 'attach': await this.chooseImages(); return
+        case 'attach-images':
+          if (typeof value.sessionId === 'string') await this.addEncodedImages(value.sessionId, value.images)
+          return
+        case 'attachment-error':
+          if (typeof value.message === 'string') await vscode.window.showWarningMessage(value.message)
+          return
         case 'choose-workspace': await this.chooseWorkspace(); return
         case 'request-mentions':
           if (typeof value.requestId === 'number' && typeof value.query === 'string') {
@@ -1636,6 +1657,30 @@ function imageMediaType(filePath: string): ImageMediaType | undefined {
     case '.webp': return 'image/webp'
     case '.gif': return 'image/gif'
     default: return undefined
+  }
+}
+
+function draftImageFromWebview(value: unknown): DraftImage | undefined {
+  if (typeof value !== 'object' || value === null) return undefined
+  const candidate = value as Record<string, unknown>
+  const mediaType = candidate.mediaType
+  if (mediaType !== 'image/png'
+    && mediaType !== 'image/jpeg'
+    && mediaType !== 'image/webp'
+    && mediaType !== 'image/gif') return undefined
+  if (typeof candidate.data !== 'string'
+    || candidate.data === ''
+    || candidate.data.length % 4 !== 0
+    || !/^[A-Za-z0-9+/]*={0,2}$/.test(candidate.data)) return undefined
+  const name = typeof candidate.name === 'string' && candidate.name.trim() !== ''
+    ? candidate.name.trim()
+    : undefined
+  return {
+    id: randomUUID(),
+    type: 'image',
+    mediaType,
+    data: candidate.data,
+    ...(name === undefined ? {} : { name }),
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1517,7 +1517,19 @@ class DshSurface implements vscode.Disposable {
           return
         case 'attach': await this.chooseImages(); return
         case 'attach-images':
-          if (typeof value.sessionId === 'string') await this.addEncodedImages(value.sessionId, value.images)
+          if (typeof value.sessionId === 'string'
+            && typeof value.requestId === 'number'
+            && Number.isSafeInteger(value.requestId)) {
+            try {
+              await this.addEncodedImages(value.sessionId, value.images)
+            } finally {
+              await this.webview.postMessage({
+                type: 'attachments-added',
+                sessionId: value.sessionId,
+                requestId: value.requestId,
+              })
+            }
+          }
           return
         case 'attachment-error':
           if (typeof value.message === 'string') await vscode.window.showWarningMessage(value.message)

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -356,6 +356,8 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
     const sessionDrafts = new Map();
     const pendingDraftSends = new Map();
     let draftSendRequestId = 0;
+    const pendingAttachmentRequests = new Map();
+    let attachmentRequestId = 0;
     const renderedMessages = new Map();
     const expandedToolIds = new Set();
     const loadingToolRequests = new Map();
@@ -1555,14 +1557,17 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       scheduleRender({ ...state, ...patch, messages });
     }
     function updateSend() {
-      const pending = state && [...pendingDraftSends.values()].some(draft => draft.sessionId === state.sessionId);
-      elements.send.disabled = !state || state.phase !== 'ready' || pending || (elements.prompt.value.trim() === '' && draftImages.length === 0);
+      const pendingSend = state && [...pendingDraftSends.values()].some(draft => draft.sessionId === state.sessionId);
+      const pendingAttachment = state && [...pendingAttachmentRequests.values()].some(request => request.sessionId === state.sessionId);
+      elements.send.disabled = !state || state.phase !== 'ready' || pendingSend || pendingAttachment || (elements.prompt.value.trim() === '' && draftImages.length === 0);
     }
     function resizePrompt() { elements.prompt.style.height = 'auto'; elements.prompt.style.height = Math.min(elements.prompt.scrollHeight, 220) + 'px'; updateSend(); }
     function selectionFor(model, reasoningEffort) { return { provider: model.provider, model: model.model, ...(reasoningEffort ? { reasoningEffort } : {}) }; }
     function send(mode) {
       const text = elements.prompt.value.trim(); if ((!text && !draftImages.length) || !state || state.phase !== 'ready') return;
-      const requestId = ++draftSendRequestId; const sessionId = state.sessionId;
+      const sessionId = state.sessionId;
+      if ([...pendingAttachmentRequests.values()].some(request => request.sessionId === sessionId)) return;
+      const requestId = ++draftSendRequestId;
       pendingDraftSends.set(requestId, { sessionId, text });
       vscode.postMessage({ type: 'send', sessionId, requestId, text, mode: mode || 'queue' }); elements.prompt.value = ''; sessionDrafts.set(sessionId, ''); commandIndex = 0; resetPrompt();
     }
@@ -1599,14 +1604,23 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       event.preventDefault();
       if (!state || state.phase !== 'ready' || !state.sessionId) return;
       const sessionId = state.sessionId;
+      const requestId = ++attachmentRequestId;
+      pendingAttachmentRequests.set(requestId, { sessionId });
+      updateSend();
       Promise.all(files.map(clipboardImage)).then(values => {
         const images = values.filter(Boolean);
         if (!images.length) {
+          pendingAttachmentRequests.delete(requestId);
+          updateSend();
           vscode.postMessage({ type: 'attachment-error', message: 'Paste a PNG, JPEG, WebP, or GIF image.' });
           return;
         }
-        vscode.postMessage({ type: 'attach-images', sessionId, images });
-      }).catch(error => vscode.postMessage({ type: 'attachment-error', message: error && error.message || 'The pasted image could not be read.' }));
+        vscode.postMessage({ type: 'attach-images', sessionId, requestId, images });
+      }).catch(error => {
+        pendingAttachmentRequests.delete(requestId);
+        updateSend();
+        vscode.postMessage({ type: 'attachment-error', message: error && error.message || 'The pasted image could not be read.' });
+      });
     });
     elements.prompt.addEventListener('keydown', event => {
       if (policyMenuOpen && event.key === 'Escape') { event.preventDefault(); policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); return; }
@@ -1696,6 +1710,13 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       if (event.data.type === 'draft-images' && typeof event.data.sessionId === 'string') {
         const images = event.data.images || []; draftImagesBySession.set(event.data.sessionId, images);
         if (state && event.data.sessionId === state.sessionId) { draftImages = images; renderAttachments(); }
+      }
+      if (event.data.type === 'attachments-added' && typeof event.data.requestId === 'number') {
+        const pending = pendingAttachmentRequests.get(event.data.requestId);
+        if (pending && pending.sessionId === event.data.sessionId) {
+          pendingAttachmentRequests.delete(event.data.requestId);
+          updateSend();
+        }
       }
       if ((event.data.type === 'draft-sent' || event.data.type === 'restore-draft') && typeof event.data.requestId === 'number') {
         const pending = pendingDraftSends.get(event.data.requestId);

--- a/src/webview.ts
+++ b/src/webview.ts
@@ -1566,8 +1566,48 @@ export function chatHtml(webview: vscode.Webview, deepseekMarkUri: vscode.Uri): 
       pendingDraftSends.set(requestId, { sessionId, text });
       vscode.postMessage({ type: 'send', sessionId, requestId, text, mode: mode || 'queue' }); elements.prompt.value = ''; sessionDrafts.set(sessionId, ''); commandIndex = 0; resetPrompt();
     }
+    function clipboardImage(file, index) {
+      const mediaType = String(file.type || '').toLowerCase();
+      if (!['image/png', 'image/jpeg', 'image/webp', 'image/gif'].includes(mediaType)) return Promise.resolve(null);
+      return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.addEventListener('load', () => {
+          const result = typeof reader.result === 'string' ? reader.result : '';
+          const separator = result.indexOf(',');
+          if (separator < 0) { reject(new Error('The pasted image could not be read.')); return; }
+          resolve({ mediaType, data: result.slice(separator + 1), name: file.name || ('pasted-image-' + String(index + 1)) });
+        });
+        reader.addEventListener('error', () => reject(new Error('The pasted image could not be read.')));
+        reader.readAsDataURL(file);
+      });
+    }
+    function clipboardImageFiles(event) {
+      const clipboard = event.clipboardData;
+      if (!clipboard) return [];
+      const itemFiles = Array.from(clipboard.items || [])
+        .filter(item => item.kind === 'file' && String(item.type || '').toLowerCase().startsWith('image/'))
+        .map(item => item.getAsFile())
+        .filter(Boolean);
+      if (itemFiles.length) return itemFiles;
+      return Array.from(clipboard.files || []).filter(file => String(file.type || '').toLowerCase().startsWith('image/'));
+    }
     elements.prompt.addEventListener('input', () => { if (state && state.sessionId) sessionDrafts.set(state.sessionId, elements.prompt.value); policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); commandIndex = 0; mentionIndex = 0; elements.prompt.placeholder = 'Ask DeepSeek about this project'; resizePrompt(); renderCommandMenu(); requestMentions(); });
     elements.prompt.addEventListener('click', () => { policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); requestMentions(); });
+    elements.prompt.addEventListener('paste', event => {
+      const files = clipboardImageFiles(event);
+      if (!files.length) return;
+      event.preventDefault();
+      if (!state || state.phase !== 'ready' || !state.sessionId) return;
+      const sessionId = state.sessionId;
+      Promise.all(files.map(clipboardImage)).then(values => {
+        const images = values.filter(Boolean);
+        if (!images.length) {
+          vscode.postMessage({ type: 'attachment-error', message: 'Paste a PNG, JPEG, WebP, or GIF image.' });
+          return;
+        }
+        vscode.postMessage({ type: 'attach-images', sessionId, images });
+      }).catch(error => vscode.postMessage({ type: 'attachment-error', message: error && error.message || 'The pasted image could not be read.' }));
+    });
     elements.prompt.addEventListener('keydown', event => {
       if (policyMenuOpen && event.key === 'Escape') { event.preventDefault(); policyMenuOpen = false; elements.policyMenu.classList.add('hidden'); elements.policyTrigger.setAttribute('aria-expanded', 'false'); return; }
       const mentionOpen = !elements.mentionMenu.classList.contains('hidden') && mentionCandidates.length > 0;

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -46,9 +46,21 @@ describe('chat webview', () => {
     expect(script).toContain("if (!files.length) return;")
     expect(script).toContain("item.getAsFile()")
     expect(script).toContain("reader.readAsDataURL(file)")
-    expect(script).toContain("type: 'attach-images', sessionId, images")
+    expect(script).toContain("type: 'attach-images', sessionId, requestId, images")
     const pasteHandler = script.slice(script.indexOf("elements.prompt.addEventListener('paste'"))
     expect(pasteHandler.indexOf("if (!files.length) return;")).toBeLessThan(pasteHandler.indexOf('event.preventDefault();'))
+  })
+
+  it('blocks sending until the extension acknowledges pasted attachments', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const script = /<script nonce="[^"]+">([\s\S]*?)<\/script>/.exec(chatHtml(webview, mark))?.[1] ?? ''
+
+    expect(script).toContain('const pendingAttachmentRequests = new Map()')
+    expect(script).toContain('pendingAttachmentRequests.set(requestId, { sessionId })')
+    expect(script).toContain("request => request.sessionId === sessionId)) return;")
+    expect(script).toContain("event.data.type === 'attachments-added'")
+    expect(script).toContain('pendingAttachmentRequests.delete(event.data.requestId)')
   })
 
   it('offers actionable setup states instead of a generic reconnect loop', () => {

--- a/tests/webview.spec.ts
+++ b/tests/webview.spec.ts
@@ -37,6 +37,20 @@ describe('chat webview', () => {
     expect(html).not.toContain('<select id="sessions"')
   })
 
+  it('attaches supported clipboard images without intercepting ordinary text paste', () => {
+    const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
+    const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri
+    const script = /<script nonce="[^"]+">([\s\S]*?)<\/script>/.exec(chatHtml(webview, mark))?.[1] ?? ''
+
+    expect(script).toContain("elements.prompt.addEventListener('paste'")
+    expect(script).toContain("if (!files.length) return;")
+    expect(script).toContain("item.getAsFile()")
+    expect(script).toContain("reader.readAsDataURL(file)")
+    expect(script).toContain("type: 'attach-images', sessionId, images")
+    const pasteHandler = script.slice(script.indexOf("elements.prompt.addEventListener('paste'"))
+    expect(pasteHandler.indexOf("if (!files.length) return;")).toBeLessThan(pasteHandler.indexOf('event.preventDefault();'))
+  })
+
   it('offers actionable setup states instead of a generic reconnect loop', () => {
     const webview = { cspSource: 'vscode-webview:' } as vscode.Webview
     const mark = { toString: () => 'vscode-resource:/deepseek.svg' } as vscode.Uri


### PR DESCRIPTION
## Summary

- support pasting clipboard images into the chat composer with Cmd/Ctrl+V
- reuse the existing attachment limits and per-session draft handling
- preserve ordinary text paste and report unsupported image formats

This addresses the clipboard-paste portion of #20. The issue remains open for the provider-specific vision and reasoning-effort reports.

## Testing

- `npm run check`
- 35 test files passed
- 174 tests passed, 1 skipped

Related to #20